### PR TITLE
fix: correct vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/berumensports.github.io/',
+  base: '/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- fix Vite base path so built assets load from root on GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9c1e1bb08325af71e785a2af8818