### PR TITLE
Add referee and catalog management with team payments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import ProtectedRoute from './auth/ProtectedRoute';
 import PrivateLayout from './layouts/PrivateLayout';
 import Dashboard from './pages/Dashboard';
 import Equipos from './pages/Equipos';
+import Arbitros from './pages/Arbitros';
+import Delegaciones from './pages/Delegaciones';
 import Temporadas from './pages/Temporadas';
 import Tarifas from './pages/Tarifas';
 import Partidos from './pages/Partidos';
@@ -24,6 +26,8 @@ export default function App() {
       >
         <Route index element={<Dashboard />} />
         <Route path="equipos" element={<Equipos />} />
+        <Route path="arbitros" element={<Arbitros />} />
+        <Route path="delegaciones" element={<Delegaciones />} />
         <Route path="temporadas" element={<Temporadas />} />
         <Route path="tarifas" element={<Tarifas />} />
         <Route path="partidos" element={<Partidos />} />

--- a/src/components/ModalAbonoForm.tsx
+++ b/src/components/ModalAbonoForm.tsx
@@ -1,14 +1,17 @@
 import { Dialog } from '@headlessui/react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { addAbono } from '../services/abonos';
+import { listEquipos } from '../services/equipos';
 
 const schema = z.object({
   fecha: z.string(),
   monto: z.coerce.number().gt(0),
   metodo: z.enum(['efectivo', 'transferencia']),
   ref: z.string().optional(),
+  equipoId: z.string().min(1),
 });
 
 export type AbonoForm = z.infer<typeof schema>;
@@ -21,18 +24,24 @@ interface Props {
 }
 
 export default function ModalAbonoForm({ open, onClose, cobroId, saldo }: Props) {
+  const [equipos, setEquipos] = useState<any[]>([]);
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<AbonoForm>({ resolver: zodResolver(schema), defaultValues: { fecha: new Date().toISOString().substring(0, 10) } });
 
+  useEffect(() => {
+    listEquipos().then(setEquipos);
+  }, []);
+
   const onSubmit = async (data: AbonoForm) => {
     if (data.monto > saldo) {
       alert('Monto excede saldo');
       return;
     }
-    await addAbono(cobroId, data);
+    const equipo = equipos.find((e) => e.id === data.equipoId);
+    await addAbono(cobroId, { ...data, equipoNombre: equipo?.nombre });
     onClose();
   };
 
@@ -50,6 +59,15 @@ export default function ModalAbonoForm({ open, onClose, cobroId, saldo }: Props)
             <option value="transferencia">Transferencia</option>
           </select>
           <input className="border p-2 w-full" placeholder="Referencia" {...register('ref')} />
+          <select className="border p-2 w-full" {...register('equipoId')}>
+            <option value="">Seleccione equipo</option>
+            {equipos.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.nombre}
+              </option>
+            ))}
+          </select>
+          {errors.equipoId && <p className="text-red-500 text-sm">Seleccione un equipo</p>}
           <div className="flex justify-end space-x-2 pt-2">
             <button type="button" className="px-3 py-1" onClick={onClose}>
               Cancelar

--- a/src/components/ModalArbitroForm.tsx
+++ b/src/components/ModalArbitroForm.tsx
@@ -1,0 +1,60 @@
+import { Dialog } from '@headlessui/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createArbitro } from '../services/arbitros';
+
+const schema = z.object({
+  nombre: z.string().min(1),
+  telefono: z.string().optional(),
+  correo: z.string().email().optional(),
+  estatus: z.enum(['activo', 'inactivo']).default('activo'),
+});
+
+export type ArbitroForm = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initialData?: Partial<ArbitroForm>;
+}
+
+export default function ModalArbitroForm({ open, onClose, initialData }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ArbitroForm>({ resolver: zodResolver(schema), defaultValues: initialData });
+
+  const onSubmit = async (data: ArbitroForm) => {
+    await createArbitro(data);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-10 flex items-center justify-center">
+      <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+      <div className="bg-white p-4 rounded shadow w-96 relative z-20 space-y-2">
+        <Dialog.Title className="text-lg font-bold">Árbitro</Dialog.Title>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <input className="border p-2 w-full" placeholder="Nombre" {...register('nombre')} />
+          {errors.nombre && <p className="text-red-500 text-sm">Requerido</p>}
+          <input className="border p-2 w-full" placeholder="Teléfono" {...register('telefono')} />
+          <input className="border p-2 w-full" placeholder="Correo" {...register('correo')} />
+          <select className="border p-2 w-full" {...register('estatus')}>
+            <option value="activo">Activo</option>
+            <option value="inactivo">Inactivo</option>
+          </select>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" className="px-3 py-1" onClick={onClose}>
+              Cancelar
+            </button>
+            <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/ModalDelegacionForm.tsx
+++ b/src/components/ModalDelegacionForm.tsx
@@ -1,0 +1,51 @@
+import { Dialog } from '@headlessui/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createDelegacion } from '../services/delegaciones';
+
+const schema = z.object({
+  nombre: z.string().min(1),
+});
+
+export type DelegacionForm = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initialData?: Partial<DelegacionForm>;
+}
+
+export default function ModalDelegacionForm({ open, onClose, initialData }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<DelegacionForm>({ resolver: zodResolver(schema), defaultValues: initialData });
+
+  const onSubmit = async (data: DelegacionForm) => {
+    await createDelegacion(data);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-10 flex items-center justify-center">
+      <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+      <div className="bg-white p-4 rounded shadow w-96 relative z-20 space-y-2">
+        <Dialog.Title className="text-lg font-bold">Delegación</Dialog.Title>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <input className="border p-2 w-full" placeholder="Nombre" {...register('nombre')} />
+          {errors.nombre && <p className="text-red-500 text-sm">Requerido</p>}
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" className="px-3 py-1" onClick={onClose}>
+              Cancelar
+            </button>
+            <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/ModalTarifaForm.tsx
+++ b/src/components/ModalTarifaForm.tsx
@@ -1,0 +1,69 @@
+import { Dialog } from '@headlessui/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createTarifa } from '../services/tarifas';
+
+const schema = z.object({
+  rama: z.enum(['Varonil', 'Femenil']),
+  categoria: z.coerce.number().min(2009).max(2020),
+  monto: z.coerce.number().gt(0),
+});
+
+export type TarifaForm = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initialData?: Partial<TarifaForm>;
+}
+
+export default function ModalTarifaForm({ open, onClose, initialData }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TarifaForm>({ resolver: zodResolver(schema), defaultValues: initialData });
+
+  const onSubmit = async (data: TarifaForm) => {
+    await createTarifa(data);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-10 flex items-center justify-center">
+      <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+      <div className="bg-white p-4 rounded shadow w-96 relative z-20 space-y-2">
+        <Dialog.Title className="text-lg font-bold">Tarifa</Dialog.Title>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <select className="border p-2 w-full" {...register('rama')}>
+            <option value="Varonil">Varonil</option>
+            <option value="Femenil">Femenil</option>
+          </select>
+          <input
+            type="number"
+            className="border p-2 w-full"
+            placeholder="Categoría"
+            {...register('categoria', { valueAsNumber: true })}
+          />
+          {errors.categoria && <p className="text-red-500 text-sm">Categoría inválida</p>}
+          <input
+            type="number"
+            className="border p-2 w-full"
+            placeholder="Monto"
+            {...register('monto', { valueAsNumber: true })}
+          />
+          {errors.monto && <p className="text-red-500 text-sm">Monto inválido</p>}
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" className="px-3 py-1" onClick={onClose}>
+              Cancelar
+            </button>
+            <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/ModalTemporadaForm.tsx
+++ b/src/components/ModalTemporadaForm.tsx
@@ -1,0 +1,60 @@
+import { Dialog } from '@headlessui/react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createTemporada } from '../services/temporadas';
+
+const schema = z.object({
+  nombre: z.string().min(1),
+  inicio: z.string(),
+  fin: z.string(),
+  activa: z.boolean().optional(),
+});
+
+export type TemporadaForm = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initialData?: Partial<TemporadaForm>;
+}
+
+export default function ModalTemporadaForm({ open, onClose, initialData }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TemporadaForm>({ resolver: zodResolver(schema), defaultValues: initialData });
+
+  const onSubmit = async (data: TemporadaForm) => {
+    await createTemporada(data);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="fixed inset-0 z-10 flex items-center justify-center">
+      <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+      <div className="bg-white p-4 rounded shadow w-96 relative z-20 space-y-2">
+        <Dialog.Title className="text-lg font-bold">Temporada</Dialog.Title>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <input className="border p-2 w-full" placeholder="Nombre" {...register('nombre')} />
+          {errors.nombre && <p className="text-red-500 text-sm">Requerido</p>}
+          <input type="date" className="border p-2 w-full" {...register('inicio')} />
+          <input type="date" className="border p-2 w-full" {...register('fin')} />
+          <label className="flex items-center space-x-2">
+            <input type="checkbox" {...register('activa')} />
+            <span>Activa</span>
+          </label>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" className="px-3 py-1" onClick={onClose}>
+              Cancelar
+            </button>
+            <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/layouts/PrivateLayout.tsx
+++ b/src/layouts/PrivateLayout.tsx
@@ -9,11 +9,15 @@ import {
   DollarSign,
   FileText,
   ClipboardList,
+  UserCheck,
+  Flag,
 } from 'lucide-react';
 
 const navItems = [
   { to: '/', icon: Home, label: 'Dashboard' },
   { to: '/equipos', icon: Users, label: 'Equipos' },
+  { to: '/arbitros', icon: UserCheck, label: 'Árbitros' },
+  { to: '/delegaciones', icon: Flag, label: 'Delegaciones' },
   { to: '/temporadas', icon: Calendar, label: 'Temporadas' },
   { to: '/tarifas', icon: ClipboardList, label: 'Tarifas' },
   { to: '/partidos', icon: Calendar, label: 'Partidos' },

--- a/src/pages/Arbitros.tsx
+++ b/src/pages/Arbitros.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react';
-import ModalTarifaForm from '../components/ModalTarifaForm';
+import ModalArbitroForm from '../components/ModalArbitroForm';
 
-export default function Tarifas() {
+export default function Arbitros() {
   const [open, setOpen] = useState(false);
   return (
     <div>
       <div className="flex justify-between mb-4">
-        <h1 className="text-2xl font-bold">Tarifas</h1>
+        <h1 className="text-2xl font-bold">Árbitros</h1>
         <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
-          Nueva tarifa
+          Nuevo árbitro
         </button>
       </div>
-      {/* tabla de tarifas pendiente */}
-      <ModalTarifaForm open={open} onClose={() => setOpen(false)} />
+      {/* tabla de árbitros pendiente */}
+      <ModalArbitroForm open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }

--- a/src/pages/Delegaciones.tsx
+++ b/src/pages/Delegaciones.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import ModalDelegacionForm from '../components/ModalDelegacionForm';
+
+export default function Delegaciones() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Delegaciones</h1>
+        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+          Nueva delegación
+        </button>
+      </div>
+      {/* tabla de delegaciones pendiente */}
+      <ModalDelegacionForm open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}

--- a/src/pages/Temporadas.tsx
+++ b/src/pages/Temporadas.tsx
@@ -1,8 +1,18 @@
+import { useState } from 'react';
+import ModalTemporadaForm from '../components/ModalTemporadaForm';
+
 export default function Temporadas() {
+  const [open, setOpen] = useState(false);
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Temporadas</h1>
-      <p>CRUD de temporadas.</p>
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Temporadas</h1>
+        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+          Nueva temporada
+        </button>
+      </div>
+      {/* tabla de temporadas pendiente */}
+      <ModalTemporadaForm open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }

--- a/src/services/abonos.ts
+++ b/src/services/abonos.ts
@@ -6,7 +6,7 @@ import { auth } from '../firebase';
 import { ligaId } from '../config';
 const temporadaId = 'TEMPORADA_DEMO';
 
-export const addAbono = async (cobroId: string, data: AbonoForm) => {
+export const addAbono = async (cobroId: string, data: AbonoForm & { equipoNombre?: string }) => {
   const user = auth.currentUser;
   const abonosCol = collection(
     db,

--- a/src/services/arbitros.ts
+++ b/src/services/arbitros.ts
@@ -1,0 +1,14 @@
+import { addDoc, collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import { ligaId } from '../config';
+
+const arbitrosCol = collection(db, 'ligas', ligaId, 'arbitros');
+
+export const createArbitro = async (data: any) => {
+  await addDoc(arbitrosCol, data);
+};
+
+export const listArbitros = async () => {
+  const snap = await getDocs(arbitrosCol);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
+};

--- a/src/services/delegaciones.ts
+++ b/src/services/delegaciones.ts
@@ -1,0 +1,14 @@
+import { addDoc, collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import { ligaId } from '../config';
+
+const delegacionesCol = collection(db, 'ligas', ligaId, 'delegaciones');
+
+export const createDelegacion = async (data: any) => {
+  await addDoc(delegacionesCol, data);
+};
+
+export const listDelegaciones = async () => {
+  const snap = await getDocs(delegacionesCol);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
+};


### PR DESCRIPTION
## Summary
- Add Árbitros page, modal and service for managing referees
- Track team on abono registration and update service
- Introduce Delegaciones, Tarifas and Temporadas catalog forms
- Extend navigation and routes for new sections

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689baf64a1d88325b4c52c6ddee15b1a