### PR TITLE
feat: add table and card views for records

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface Props<T> {
+  data: T[];
+  render: (item: T) => React.ReactNode;
+}
+
+export default function CardList<T>({ data, render }: Props<T>) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {data.map((item, idx) => (
+        <div key={idx} className="p-4 bg-white rounded shadow">
+          {render(item)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/RecordView.tsx
+++ b/src/components/RecordView.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import DataTable, { Column } from './DataTable';
+import CardList from './CardList';
+
+interface Props<T> {
+  columns: Column<T>[];
+  data: T[];
+  cardRender: (row: T) => React.ReactNode;
+}
+
+export default function RecordView<T>({ columns, data, cardRender }: Props<T>) {
+  const [view, setView] = useState<'table' | 'cards'>('table');
+
+  return (
+    <div>
+      <div className="flex justify-end mb-2 space-x-2">
+        <button
+          className={`px-2 py-1 border rounded ${view === 'table' ? 'bg-gray-200' : ''}`}
+          onClick={() => setView('table')}
+        >
+          Tabla
+        </button>
+        <button
+          className={`px-2 py-1 border rounded ${view === 'cards' ? 'bg-gray-200' : ''}`}
+          onClick={() => setView('cards')}
+        >
+          Tarjetas
+        </button>
+      </div>
+      {view === 'table' ? (
+        <DataTable columns={columns} data={data} />
+      ) : (
+        <CardList data={data} render={cardRender} />
+      )}
+    </div>
+  );
+}

--- a/src/pages/Arbitros.tsx
+++ b/src/pages/Arbitros.tsx
@@ -1,8 +1,27 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalArbitroForm from '../components/ModalArbitroForm';
+
+interface Arbitro {
+  nombre: string;
+  telefono: string;
+  categoria: string;
+}
 
 export default function Arbitros() {
   const [open, setOpen] = useState(false);
+
+  const arbitros: Arbitro[] = [
+    { nombre: 'Juan Pérez', telefono: '555-1234', categoria: 'A' },
+  ];
+
+  const columns: Column<Arbitro>[] = [
+    { key: 'nombre', header: 'Nombre' },
+    { key: 'telefono', header: 'Teléfono' },
+    { key: 'categoria', header: 'Categoría' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,7 +30,17 @@ export default function Arbitros() {
           Nuevo árbitro
         </button>
       </div>
-      {/* tabla de árbitros pendiente */}
+      <RecordView
+        columns={columns}
+        data={arbitros}
+        cardRender={(a) => (
+          <div>
+            <div className="font-bold">{a.nombre}</div>
+            <div>{a.telefono}</div>
+            <div>{a.categoria}</div>
+          </div>
+        )}
+      />
       <ModalArbitroForm open={open} onClose={() => setOpen(false)} />
     </div>
   );

--- a/src/pages/Cobros.tsx
+++ b/src/pages/Cobros.tsx
@@ -1,8 +1,27 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalAbonoForm from '../components/ModalAbonoForm';
+
+interface CobroRecord {
+  equipo: string;
+  monto: number;
+  fecha: string;
+}
 
 export default function Cobros() {
   const [open, setOpen] = useState(false);
+
+  const cobros: CobroRecord[] = [
+    { equipo: 'Tigres', monto: 100, fecha: '2024-01-01' },
+  ];
+
+  const columns: Column<CobroRecord>[] = [
+    { key: 'equipo', header: 'Equipo' },
+    { key: 'monto', header: 'Monto' },
+    { key: 'fecha', header: 'Fecha' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,6 +30,17 @@ export default function Cobros() {
           Registrar abono
         </button>
       </div>
+      <RecordView
+        columns={columns}
+        data={cobros}
+        cardRender={(c) => (
+          <div>
+            <div className="font-bold">{c.equipo}</div>
+            <div>Monto: {c.monto}</div>
+            <div>{c.fecha}</div>
+          </div>
+        )}
+      />
       <ModalAbonoForm open={open} onClose={() => setOpen(false)} cobroId="demo" saldo={100} />
     </div>
   );

--- a/src/pages/Delegaciones.tsx
+++ b/src/pages/Delegaciones.tsx
@@ -1,8 +1,25 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalDelegacionForm from '../components/ModalDelegacionForm';
+
+interface Delegacion {
+  nombre: string;
+  contacto: string;
+}
 
 export default function Delegaciones() {
   const [open, setOpen] = useState(false);
+
+  const delegaciones: Delegacion[] = [
+    { nombre: 'Delegación Norte', contacto: 'Carlos' },
+  ];
+
+  const columns: Column<Delegacion>[] = [
+    { key: 'nombre', header: 'Nombre' },
+    { key: 'contacto', header: 'Contacto' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,7 +28,16 @@ export default function Delegaciones() {
           Nueva delegación
         </button>
       </div>
-      {/* tabla de delegaciones pendiente */}
+      <RecordView
+        columns={columns}
+        data={delegaciones}
+        cardRender={(d) => (
+          <div>
+            <div className="font-bold">{d.nombre}</div>
+            <div>{d.contacto}</div>
+          </div>
+        )}
+      />
       <ModalDelegacionForm open={open} onClose={() => setOpen(false)} />
     </div>
   );

--- a/src/pages/Equipos.tsx
+++ b/src/pages/Equipos.tsx
@@ -1,8 +1,25 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalEquipoForm from '../components/ModalEquipoForm';
+
+interface Equipo {
+  nombre: string;
+  delegacion: string;
+}
 
 export default function Equipos() {
   const [open, setOpen] = useState(false);
+
+  const equipos: Equipo[] = [
+    { nombre: 'Tigres', delegacion: 'Norte' },
+  ];
+
+  const columns: Column<Equipo>[] = [
+    { key: 'nombre', header: 'Nombre' },
+    { key: 'delegacion', header: 'Delegación' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,7 +28,16 @@ export default function Equipos() {
           Nuevo equipo
         </button>
       </div>
-      {/* tabla de equipos pendiente */}
+      <RecordView
+        columns={columns}
+        data={equipos}
+        cardRender={(e) => (
+          <div>
+            <div className="font-bold">{e.nombre}</div>
+            <div>{e.delegacion}</div>
+          </div>
+        )}
+      />
       <ModalEquipoForm open={open} onClose={() => setOpen(false)} />
     </div>
   );

--- a/src/pages/Partidos.tsx
+++ b/src/pages/Partidos.tsx
@@ -1,8 +1,27 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalPartidoForm from '../components/ModalPartidoForm';
+
+interface Partido {
+  local: string;
+  visitante: string;
+  fecha: string;
+}
 
 export default function Partidos() {
   const [open, setOpen] = useState(false);
+
+  const partidos: Partido[] = [
+    { local: 'Tigres', visitante: 'Leones', fecha: '2024-01-10' },
+  ];
+
+  const columns: Column<Partido>[] = [
+    { key: 'local', header: 'Local' },
+    { key: 'visitante', header: 'Visitante' },
+    { key: 'fecha', header: 'Fecha' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,6 +30,18 @@ export default function Partidos() {
           Nuevo partido
         </button>
       </div>
+      <RecordView
+        columns={columns}
+        data={partidos}
+        cardRender={(p) => (
+          <div>
+            <div className="font-bold">
+              {p.local} vs {p.visitante}
+            </div>
+            <div>{p.fecha}</div>
+          </div>
+        )}
+      />
       <ModalPartidoForm open={open} onClose={() => setOpen(false)} />
     </div>
   );

--- a/src/pages/Tarifas.tsx
+++ b/src/pages/Tarifas.tsx
@@ -1,8 +1,25 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalTarifaForm from '../components/ModalTarifaForm';
+
+interface Tarifa {
+  concepto: string;
+  monto: number;
+}
 
 export default function Tarifas() {
   const [open, setOpen] = useState(false);
+
+  const tarifas: Tarifa[] = [
+    { concepto: 'Inscripción', monto: 50 },
+  ];
+
+  const columns: Column<Tarifa>[] = [
+    { key: 'concepto', header: 'Concepto' },
+    { key: 'monto', header: 'Monto' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,7 +28,16 @@ export default function Tarifas() {
           Nueva tarifa
         </button>
       </div>
-      {/* tabla de tarifas pendiente */}
+      <RecordView
+        columns={columns}
+        data={tarifas}
+        cardRender={(t) => (
+          <div>
+            <div className="font-bold">{t.concepto}</div>
+            <div>Monto: {t.monto}</div>
+          </div>
+        )}
+      />
       <ModalTarifaForm open={open} onClose={() => setOpen(false)} />
     </div>
   );

--- a/src/pages/Temporadas.tsx
+++ b/src/pages/Temporadas.tsx
@@ -1,8 +1,25 @@
 import { useState } from 'react';
+import { Column } from '../components/DataTable';
+import RecordView from '../components/RecordView';
 import ModalTemporadaForm from '../components/ModalTemporadaForm';
+
+interface Temporada {
+  nombre: string;
+  anio: number;
+}
 
 export default function Temporadas() {
   const [open, setOpen] = useState(false);
+
+  const temporadas: Temporada[] = [
+    { nombre: 'Apertura', anio: 2024 },
+  ];
+
+  const columns: Column<Temporada>[] = [
+    { key: 'nombre', header: 'Nombre' },
+    { key: 'anio', header: 'Año' },
+  ];
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -11,7 +28,16 @@ export default function Temporadas() {
           Nueva temporada
         </button>
       </div>
-      {/* tabla de temporadas pendiente */}
+      <RecordView
+        columns={columns}
+        data={temporadas}
+        cardRender={(t) => (
+          <div>
+            <div className="font-bold">{t.nombre}</div>
+            <div>{t.anio}</div>
+          </div>
+        )}
+      />
       <ModalTemporadaForm open={open} onClose={() => setOpen(false)} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add generic CardList and RecordView components with table/card toggle
- display sample data for sections like Árbitros, Cobros, Delegaciones, Equipos, Partidos, Tarifas and Temporadas

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb9fc7e208325adb0fb909536f8fd