### PR TITLE
feat: add hamburger navigation menu

### DIFF
--- a/src/layouts/PrivateLayout.tsx
+++ b/src/layouts/PrivateLayout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useAuth } from '../auth/AuthProvider';
 import { signOut } from 'firebase/auth';
@@ -11,7 +12,10 @@ import {
   ClipboardList,
   UserCheck,
   Flag,
+  Menu as MenuIcon,
+  X,
 } from 'lucide-react';
+import { Dialog } from '@headlessui/react';
 
 const navItems = [
   { to: '/', icon: Home, label: 'Dashboard' },
@@ -27,40 +31,62 @@ const navItems = [
 
 export default function PrivateLayout() {
   const { user, role } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <div className="flex min-h-screen">
-      <aside className="w-48 bg-gray-800 text-white p-4 space-y-2">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            className={({ isActive }) =>
-              `flex items-center space-x-2 p-2 rounded hover:bg-gray-700 ${
-                isActive ? 'bg-gray-700' : ''
-              }`
-            }
-            end
-          >
-            <item.icon className="w-4" />
-            <span>{item.label}</span>
-          </NavLink>
-        ))}
-      </aside>
-      <main className="flex-1">
-        <header className="flex justify-between items-center p-4 border-b">
-          <div>
-            {user?.displayName} ({role})
-          </div>
+    <div className="min-h-screen flex flex-col">
+      <Dialog
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        className="relative z-50"
+      >
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+        <Dialog.Panel className="fixed inset-y-0 left-0 w-48 bg-gray-800 text-white p-4 space-y-2">
           <button
-            className="text-sm text-blue-500"
-            onClick={() => signOut(auth)}
+            className="absolute top-4 right-4 text-white"
+            onClick={() => setMenuOpen(false)}
           >
-            Cerrar sesión
+            <X />
           </button>
-        </header>
-        <div className="p-4">
-          <Outlet />
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                `flex items-center space-x-2 p-2 rounded hover:bg-gray-700 ${
+                  isActive ? 'bg-gray-700' : ''
+                }`
+              }
+              onClick={() => setMenuOpen(false)}
+              end
+            >
+              <item.icon className="w-4" />
+              <span>{item.label}</span>
+            </NavLink>
+          ))}
+        </Dialog.Panel>
+      </Dialog>
+
+      <header className="flex items-center justify-between p-4 border-b">
+        <button
+          className="p-2"
+          onClick={() => setMenuOpen(true)}
+        >
+          <MenuIcon />
+        </button>
+        <div>
+          {user?.displayName} ({role})
         </div>
+        <button
+          className="text-sm text-blue-500"
+          onClick={() => signOut(auth)}
+        >
+          Cerrar sesión
+        </button>
+      </header>
+
+      <main className="flex-1 p-4">
+        <Outlet />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace static sidebar with hamburger menu that opens from the left
- menu closes on X button, outside click, or selecting a menu item

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be657e21883259f420744ac111eab