### PR TITLE
feat: allow editing and deleting records

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -3,13 +3,37 @@ import React from 'react';
 interface Props<T> {
   data: T[];
   render: (item: T) => React.ReactNode;
+  onEdit?: (item: T, idx: number) => void;
+  onDelete?: (item: T, idx: number) => void;
 }
 
-export default function CardList<T>({ data, render }: Props<T>) {
+export default function CardList<T>({ data, render, onEdit, onDelete }: Props<T>) {
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {data.map((item, idx) => (
-        <div key={idx} className="p-4 bg-white rounded shadow">
+        <div key={idx} className="p-4 bg-white rounded shadow relative">
+          {(onEdit || onDelete) && (
+            <div className="absolute top-2 right-2 space-x-2 text-sm">
+              {onEdit && (
+                <button
+                  type="button"
+                  className="text-blue-500"
+                  onClick={() => onEdit(item, idx)}
+                >
+                  Editar
+                </button>
+              )}
+              {onDelete && (
+                <button
+                  type="button"
+                  className="text-red-500"
+                  onClick={() => onDelete(item, idx)}
+                >
+                  Eliminar
+                </button>
+              )}
+            </div>
+          )}
           {render(item)}
         </div>
       ))}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -6,7 +6,17 @@ export interface Column<T> {
   render?: (row: T) => React.ReactNode;
 }
 
-export default function DataTable<T>({ columns, data }: { columns: Column<T>[]; data: T[] }) {
+export default function DataTable<T>({
+  columns,
+  data,
+  onEdit,
+  onDelete,
+}: {
+  columns: Column<T>[];
+  data: T[];
+  onEdit?: (row: T, idx: number) => void;
+  onDelete?: (row: T, idx: number) => void;
+}) {
   return (
     <table className="min-w-full border">
       <thead className="bg-gray-100">
@@ -16,6 +26,7 @@ export default function DataTable<T>({ columns, data }: { columns: Column<T>[]; 
               {c.header}
             </th>
           ))}
+          {(onEdit || onDelete) && <th className="px-2 py-1 border">Acciones</th>}
         </tr>
       </thead>
       <tbody>
@@ -26,6 +37,28 @@ export default function DataTable<T>({ columns, data }: { columns: Column<T>[]; 
                 {c.render ? c.render(row) : (row as any)[c.key]}
               </td>
             ))}
+            {(onEdit || onDelete) && (
+              <td className="px-2 py-1 border space-x-2">
+                {onEdit && (
+                  <button
+                    type="button"
+                    className="text-blue-500"
+                    onClick={() => onEdit(row, idx)}
+                  >
+                    Editar
+                  </button>
+                )}
+                {onDelete && (
+                  <button
+                    type="button"
+                    className="text-red-500"
+                    onClick={() => onDelete(row, idx)}
+                  >
+                    Eliminar
+                  </button>
+                )}
+              </td>
+            )}
           </tr>
         ))}
       </tbody>

--- a/src/components/ModalAbonoForm.tsx
+++ b/src/components/ModalAbonoForm.tsx
@@ -21,15 +21,20 @@ interface Props {
   onClose: () => void;
   cobroId: string;
   saldo: number;
+  onSave?: (data: AbonoForm) => void;
+  initialData?: Partial<AbonoForm>;
 }
 
-export default function ModalAbonoForm({ open, onClose, cobroId, saldo }: Props) {
+export default function ModalAbonoForm({ open, onClose, cobroId, saldo, onSave, initialData }: Props) {
   const [equipos, setEquipos] = useState<any[]>([]);
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<AbonoForm>({ resolver: zodResolver(schema), defaultValues: { fecha: new Date().toISOString().substring(0, 10) } });
+  } = useForm<AbonoForm>({
+    resolver: zodResolver(schema),
+    defaultValues: { fecha: new Date().toISOString().substring(0, 10), ...initialData },
+  });
 
   useEffect(() => {
     listEquipos().then(setEquipos);
@@ -42,6 +47,7 @@ export default function ModalAbonoForm({ open, onClose, cobroId, saldo }: Props)
     }
     const equipo = equipos.find((e) => e.id === data.equipoId);
     await addAbono(cobroId, { ...data, equipoNombre: equipo?.nombre });
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalArbitroForm.tsx
+++ b/src/components/ModalArbitroForm.tsx
@@ -16,10 +16,11 @@ export type ArbitroForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: ArbitroForm) => void;
   initialData?: Partial<ArbitroForm>;
 }
 
-export default function ModalArbitroForm({ open, onClose, initialData }: Props) {
+export default function ModalArbitroForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -28,6 +29,7 @@ export default function ModalArbitroForm({ open, onClose, initialData }: Props) 
 
   const onSubmit = async (data: ArbitroForm) => {
     await createArbitro(data);
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalDelegacionForm.tsx
+++ b/src/components/ModalDelegacionForm.tsx
@@ -13,10 +13,11 @@ export type DelegacionForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: DelegacionForm) => void;
   initialData?: Partial<DelegacionForm>;
 }
 
-export default function ModalDelegacionForm({ open, onClose, initialData }: Props) {
+export default function ModalDelegacionForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -25,6 +26,7 @@ export default function ModalDelegacionForm({ open, onClose, initialData }: Prop
 
   const onSubmit = async (data: DelegacionForm) => {
     await createDelegacion(data);
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalEquipoForm.tsx
+++ b/src/components/ModalEquipoForm.tsx
@@ -17,10 +17,11 @@ export type EquipoForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: EquipoForm) => void;
   initialData?: Partial<EquipoForm>;
 }
 
-export default function ModalEquipoForm({ open, onClose, initialData }: Props) {
+export default function ModalEquipoForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -29,6 +30,7 @@ export default function ModalEquipoForm({ open, onClose, initialData }: Props) {
 
   const onSubmit = async (data: EquipoForm) => {
     await createEquipo(data);
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalPartidoForm.tsx
+++ b/src/components/ModalPartidoForm.tsx
@@ -26,10 +26,11 @@ export type PartidoForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: PartidoForm) => void;
   initialData?: Partial<PartidoForm>;
 }
 
-export default function ModalPartidoForm({ open, onClose, initialData }: Props) {
+export default function ModalPartidoForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -38,6 +39,7 @@ export default function ModalPartidoForm({ open, onClose, initialData }: Props) 
 
   const onSubmit = async (data: PartidoForm) => {
     await createPartido({ ...data, estado: 'programado' });
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalTarifaForm.tsx
+++ b/src/components/ModalTarifaForm.tsx
@@ -15,10 +15,11 @@ export type TarifaForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: TarifaForm) => void;
   initialData?: Partial<TarifaForm>;
 }
 
-export default function ModalTarifaForm({ open, onClose, initialData }: Props) {
+export default function ModalTarifaForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -27,6 +28,7 @@ export default function ModalTarifaForm({ open, onClose, initialData }: Props) {
 
   const onSubmit = async (data: TarifaForm) => {
     await createTarifa(data);
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/ModalTemporadaForm.tsx
+++ b/src/components/ModalTemporadaForm.tsx
@@ -16,10 +16,11 @@ export type TemporadaForm = z.infer<typeof schema>;
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSave?: (data: TemporadaForm) => void;
   initialData?: Partial<TemporadaForm>;
 }
 
-export default function ModalTemporadaForm({ open, onClose, initialData }: Props) {
+export default function ModalTemporadaForm({ open, onClose, onSave, initialData }: Props) {
   const {
     register,
     handleSubmit,
@@ -28,6 +29,7 @@ export default function ModalTemporadaForm({ open, onClose, initialData }: Props
 
   const onSubmit = async (data: TemporadaForm) => {
     await createTemporada(data);
+    onSave?.(data);
     onClose();
   };
 

--- a/src/components/RecordView.tsx
+++ b/src/components/RecordView.tsx
@@ -6,9 +6,11 @@ interface Props<T> {
   columns: Column<T>[];
   data: T[];
   cardRender: (row: T) => React.ReactNode;
+  onEdit?: (row: T, idx: number) => void;
+  onDelete?: (row: T, idx: number) => void;
 }
 
-export default function RecordView<T>({ columns, data, cardRender }: Props<T>) {
+export default function RecordView<T>({ columns, data, cardRender, onEdit, onDelete }: Props<T>) {
   const [view, setView] = useState<'table' | 'cards'>('table');
 
   return (
@@ -28,9 +30,9 @@ export default function RecordView<T>({ columns, data, cardRender }: Props<T>) {
         </button>
       </div>
       {view === 'table' ? (
-        <DataTable columns={columns} data={data} />
+        <DataTable columns={columns} data={data} onEdit={onEdit} onDelete={onDelete} />
       ) : (
-        <CardList data={data} render={cardRender} />
+        <CardList data={data} render={cardRender} onEdit={onEdit} onDelete={onDelete} />
       )}
     </div>
   );

--- a/src/pages/Arbitros.tsx
+++ b/src/pages/Arbitros.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalArbitroForm from '../components/ModalArbitroForm';
+import ModalArbitroForm, { ArbitroForm } from '../components/ModalArbitroForm';
 
 interface Arbitro {
   nombre: string;
@@ -11,10 +11,10 @@ interface Arbitro {
 
 export default function Arbitros() {
   const [open, setOpen] = useState(false);
-
-  const arbitros: Arbitro[] = [
+  const [arbitros, setArbitros] = useState<Arbitro[]>([
     { nombre: 'Juan Pérez', telefono: '555-1234', categoria: 'A' },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Arbitro>[] = [
     { key: 'nombre', header: 'Nombre' },
@@ -26,13 +26,26 @@ export default function Arbitros() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Árbitros</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nuevo árbitro
         </button>
       </div>
       <RecordView
         columns={columns}
         data={arbitros}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setArbitros((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(a) => (
           <div>
             <div className="font-bold">{a.nombre}</div>
@@ -41,7 +54,23 @@ export default function Arbitros() {
           </div>
         )}
       />
-      <ModalArbitroForm open={open} onClose={() => setOpen(false)} />
+      <ModalArbitroForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? arbitros[editing] : undefined}
+        onSave={(data: ArbitroForm) => {
+          setArbitros((prev) => {
+            const item = data as unknown as Arbitro;
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Cobros.tsx
+++ b/src/pages/Cobros.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalAbonoForm from '../components/ModalAbonoForm';
+import ModalAbonoForm, { AbonoForm } from '../components/ModalAbonoForm';
 
 interface CobroRecord {
   equipo: string;
@@ -11,10 +11,10 @@ interface CobroRecord {
 
 export default function Cobros() {
   const [open, setOpen] = useState(false);
-
-  const cobros: CobroRecord[] = [
+  const [cobros, setCobros] = useState<CobroRecord[]>([
     { equipo: 'Tigres', monto: 100, fecha: '2024-01-01' },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<CobroRecord>[] = [
     { key: 'equipo', header: 'Equipo' },
@@ -26,13 +26,26 @@ export default function Cobros() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Cobros</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Registrar abono
         </button>
       </div>
       <RecordView
         columns={columns}
         data={cobros}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setCobros((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(c) => (
           <div>
             <div className="font-bold">{c.equipo}</div>
@@ -41,7 +54,29 @@ export default function Cobros() {
           </div>
         )}
       />
-      <ModalAbonoForm open={open} onClose={() => setOpen(false)} cobroId="demo" saldo={100} />
+      <ModalAbonoForm
+        open={open}
+        onClose={() => setOpen(false)}
+        cobroId="demo"
+        saldo={100}
+        initialData={editing !== null ? cobros[editing] : undefined}
+        onSave={(data: AbonoForm) => {
+          const item: CobroRecord = {
+            equipo: data.equipoId,
+            monto: data.monto,
+            fecha: data.fecha,
+          };
+          setCobros((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Delegaciones.tsx
+++ b/src/pages/Delegaciones.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalDelegacionForm from '../components/ModalDelegacionForm';
+import ModalDelegacionForm, { DelegacionForm } from '../components/ModalDelegacionForm';
 
 interface Delegacion {
   nombre: string;
@@ -10,10 +10,10 @@ interface Delegacion {
 
 export default function Delegaciones() {
   const [open, setOpen] = useState(false);
-
-  const delegaciones: Delegacion[] = [
+  const [delegaciones, setDelegaciones] = useState<Delegacion[]>([
     { nombre: 'Delegación Norte', contacto: 'Carlos' },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Delegacion>[] = [
     { key: 'nombre', header: 'Nombre' },
@@ -24,13 +24,26 @@ export default function Delegaciones() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Delegaciones</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nueva delegación
         </button>
       </div>
       <RecordView
         columns={columns}
         data={delegaciones}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setDelegaciones((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(d) => (
           <div>
             <div className="font-bold">{d.nombre}</div>
@@ -38,7 +51,26 @@ export default function Delegaciones() {
           </div>
         )}
       />
-      <ModalDelegacionForm open={open} onClose={() => setOpen(false)} />
+      <ModalDelegacionForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? delegaciones[editing] : undefined}
+        onSave={(data: DelegacionForm) => {
+          const item: Delegacion = {
+            nombre: data.nombre,
+            contacto: editing !== null ? delegaciones[editing].contacto : '',
+          };
+          setDelegaciones((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Equipos.tsx
+++ b/src/pages/Equipos.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalEquipoForm from '../components/ModalEquipoForm';
+import ModalEquipoForm, { EquipoForm } from '../components/ModalEquipoForm';
 
 interface Equipo {
   nombre: string;
@@ -10,10 +10,10 @@ interface Equipo {
 
 export default function Equipos() {
   const [open, setOpen] = useState(false);
-
-  const equipos: Equipo[] = [
+  const [equipos, setEquipos] = useState<Equipo[]>([
     { nombre: 'Tigres', delegacion: 'Norte' },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Equipo>[] = [
     { key: 'nombre', header: 'Nombre' },
@@ -24,13 +24,26 @@ export default function Equipos() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Equipos</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nuevo equipo
         </button>
       </div>
       <RecordView
         columns={columns}
         data={equipos}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setEquipos((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(e) => (
           <div>
             <div className="font-bold">{e.nombre}</div>
@@ -38,7 +51,26 @@ export default function Equipos() {
           </div>
         )}
       />
-      <ModalEquipoForm open={open} onClose={() => setOpen(false)} />
+      <ModalEquipoForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? equipos[editing] : undefined}
+        onSave={(data: EquipoForm) => {
+          const item: Equipo = {
+            nombre: data.nombre,
+            delegacion: data.delegacionId,
+          };
+          setEquipos((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Partidos.tsx
+++ b/src/pages/Partidos.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalPartidoForm from '../components/ModalPartidoForm';
+import ModalPartidoForm, { PartidoForm } from '../components/ModalPartidoForm';
 
 interface Partido {
   local: string;
@@ -11,10 +11,10 @@ interface Partido {
 
 export default function Partidos() {
   const [open, setOpen] = useState(false);
-
-  const partidos: Partido[] = [
+  const [partidos, setPartidos] = useState<Partido[]>([
     { local: 'Tigres', visitante: 'Leones', fecha: '2024-01-10' },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Partido>[] = [
     { key: 'local', header: 'Local' },
@@ -26,13 +26,26 @@ export default function Partidos() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Partidos</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nuevo partido
         </button>
       </div>
       <RecordView
         columns={columns}
         data={partidos}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setPartidos((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(p) => (
           <div>
             <div className="font-bold">
@@ -42,7 +55,27 @@ export default function Partidos() {
           </div>
         )}
       />
-      <ModalPartidoForm open={open} onClose={() => setOpen(false)} />
+      <ModalPartidoForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? (partidos[editing] as any) : undefined}
+        onSave={(data: PartidoForm) => {
+          const item: Partido = {
+            local: data.localId,
+            visitante: data.visitaId,
+            fecha: data.fecha,
+          };
+          setPartidos((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Tarifas.tsx
+++ b/src/pages/Tarifas.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalTarifaForm from '../components/ModalTarifaForm';
+import ModalTarifaForm, { TarifaForm } from '../components/ModalTarifaForm';
 
 interface Tarifa {
   concepto: string;
@@ -10,10 +10,10 @@ interface Tarifa {
 
 export default function Tarifas() {
   const [open, setOpen] = useState(false);
-
-  const tarifas: Tarifa[] = [
+  const [tarifas, setTarifas] = useState<Tarifa[]>([
     { concepto: 'Inscripción', monto: 50 },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Tarifa>[] = [
     { key: 'concepto', header: 'Concepto' },
@@ -24,13 +24,26 @@ export default function Tarifas() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Tarifas</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nueva tarifa
         </button>
       </div>
       <RecordView
         columns={columns}
         data={tarifas}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setTarifas((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(t) => (
           <div>
             <div className="font-bold">{t.concepto}</div>
@@ -38,7 +51,26 @@ export default function Tarifas() {
           </div>
         )}
       />
-      <ModalTarifaForm open={open} onClose={() => setOpen(false)} />
+      <ModalTarifaForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? tarifas[editing] : undefined}
+        onSave={(data: TarifaForm) => {
+          const item: Tarifa = {
+            concepto: `${data.rama} ${data.categoria}`,
+            monto: data.monto,
+          };
+          setTarifas((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Temporadas.tsx
+++ b/src/pages/Temporadas.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
-import ModalTemporadaForm from '../components/ModalTemporadaForm';
+import ModalTemporadaForm, { TemporadaForm } from '../components/ModalTemporadaForm';
 
 interface Temporada {
   nombre: string;
@@ -10,10 +10,10 @@ interface Temporada {
 
 export default function Temporadas() {
   const [open, setOpen] = useState(false);
-
-  const temporadas: Temporada[] = [
+  const [temporadas, setTemporadas] = useState<Temporada[]>([
     { nombre: 'Apertura', anio: 2024 },
-  ];
+  ]);
+  const [editing, setEditing] = useState<number | null>(null);
 
   const columns: Column<Temporada>[] = [
     { key: 'nombre', header: 'Nombre' },
@@ -24,13 +24,26 @@ export default function Temporadas() {
     <div>
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Temporadas</h1>
-        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={() => setOpen(true)}>
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => {
+            setEditing(null);
+            setOpen(true);
+          }}
+        >
           Nueva temporada
         </button>
       </div>
       <RecordView
         columns={columns}
         data={temporadas}
+        onEdit={(_, idx) => {
+          setEditing(idx);
+          setOpen(true);
+        }}
+        onDelete={(_, idx) =>
+          setTemporadas((prev) => prev.filter((_, i) => i !== idx))
+        }
         cardRender={(t) => (
           <div>
             <div className="font-bold">{t.nombre}</div>
@@ -38,7 +51,26 @@ export default function Temporadas() {
           </div>
         )}
       />
-      <ModalTemporadaForm open={open} onClose={() => setOpen(false)} />
+      <ModalTemporadaForm
+        open={open}
+        onClose={() => setOpen(false)}
+        initialData={editing !== null ? (temporadas[editing] as any) : undefined}
+        onSave={(data: TemporadaForm) => {
+          const item: Temporada = {
+            nombre: data.nombre,
+            anio: new Date(data.inicio).getFullYear(),
+          };
+          setTemporadas((prev) => {
+            if (editing !== null) {
+              const copy = [...prev];
+              copy[editing] = item;
+              return copy;
+            }
+            return [...prev, item];
+          });
+          setEditing(null);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add edit and delete actions to tables and card lists
- wire view pages and modals to support editing and removal of records

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0bf6cd3c83258a20a7c47596ca2a