### PR TITLE
feat: add page header and action bar to delegaciones

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+import SearchInput from './SearchInput';
+
+interface ActionBarProps {
+  search: string;
+  onSearch: (value: string) => void;
+  view: 'table' | 'cards';
+  onViewChange: (view: 'table' | 'cards') => void;
+  actions?: ReactNode;
+}
+
+export default function ActionBar({ search, onSearch, view, onViewChange, actions }: ActionBarProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">
+      <div className="flex items-center gap-2">
+        <SearchInput value={search} onChange={onSearch} debounce={300} />
+        <div className="flex border border-[color:var(--border)] rounded overflow-hidden">
+          <button
+            type="button"
+            onClick={() => onViewChange('table')}
+            aria-label="Vista tabla"
+            className={`px-2 py-1 text-sm transition-all ${view === 'table' ? 'bg-[color:var(--primary)] text-white' : 'bg-white text-[color:var(--text)]'}`}
+          >
+            Tabla
+          </button>
+          <button
+            type="button"
+            onClick={() => onViewChange('cards')}
+            aria-label="Vista tarjetas"
+            className={`px-2 py-1 text-sm transition-all ${view === 'cards' ? 'bg-[color:var(--primary)] text-white' : 'bg-white text-[color:var(--text)]'}`}
+          >
+            Tarjetas
+          </button>
+        </div>
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import { Box } from 'lucide-react';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}
+
+export default function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center text-center py-10">
+      <Box className="w-12 h-12 text-[color:var(--text-muted)] mb-4" aria-hidden="true" />
+      <h3 className="text-lg font-medium mb-1">{title}</h3>
+      {description && <p className="text-sm text-[color:var(--text-muted)] mb-4">{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  count?: number;
+  view?: 'table' | 'cards';
+  actions?: ReactNode;
+}
+
+export default function PageHeader({ title, subtitle, count, view, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-4 flex items-start justify-between flex-col sm:flex-row sm:items-center">
+      <div>
+        <h1 className="text-2xl font-semibold text-[color:var(--text)]">{title}</h1>
+        {(subtitle || typeof count === 'number') && (
+          <p className="text-sm text-[color:var(--text-muted)] mt-1">
+            {subtitle}
+            {typeof count === 'number' && view && (
+              <>
+                {subtitle ? ' • ' : ''}
+                {count} registros • Vista {view === 'table' ? 'Tabla' : 'Tarjetas'}
+              </>
+            )}
+          </p>
+        )}
+      </div>
+      {actions && <div className="mt-2 sm:mt-0 flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/RecordView.tsx
+++ b/src/components/RecordView.tsx
@@ -8,27 +8,31 @@ interface Props<T> {
   cardRender: (row: T) => React.ReactNode;
   onEdit?: (row: T, idx: number) => void;
   onDelete?: (row: T, idx: number) => void;
+  view?: 'table' | 'cards';
 }
 
-export default function RecordView<T>({ columns, data, cardRender, onEdit, onDelete }: Props<T>) {
-  const [view, setView] = useState<'table' | 'cards'>('table');
+export default function RecordView<T>({ columns, data, cardRender, onEdit, onDelete, view: controlledView }: Props<T>) {
+  const [internalView, setInternalView] = useState<'table' | 'cards'>(controlledView ?? 'table');
+  const view = controlledView ?? internalView;
 
   return (
     <div>
-      <div className="flex justify-end mb-2 space-x-2">
-        <button
-          className={`px-2 py-1 border rounded ${view === 'table' ? 'bg-gray-200' : ''}`}
-          onClick={() => setView('table')}
-        >
-          Tabla
-        </button>
-        <button
-          className={`px-2 py-1 border rounded ${view === 'cards' ? 'bg-gray-200' : ''}`}
-          onClick={() => setView('cards')}
-        >
-          Tarjetas
-        </button>
-      </div>
+      {!controlledView && (
+        <div className="flex justify-end mb-2 space-x-2">
+          <button
+            className={`px-2 py-1 border rounded ${view === 'table' ? 'bg-gray-200' : ''}`}
+            onClick={() => setInternalView('table')}
+          >
+            Tabla
+          </button>
+          <button
+            className={`px-2 py-1 border rounded ${view === 'cards' ? 'bg-gray-200' : ''}`}
+            onClick={() => setInternalView('cards')}
+          >
+            Tarjetas
+          </button>
+        </div>
+      )}
       {view === 'table' ? (
         <DataTable columns={columns} data={data} onEdit={onEdit} onDelete={onDelete} />
       ) : (

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  debounce?: number;
+}
+
+export default function SearchInput({ value, onChange, debounce = 300 }: SearchInputProps) {
+  const [internal, setInternal] = useState(value);
+
+  useEffect(() => setInternal(value), [value]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => onChange(internal), debounce);
+    return () => clearTimeout(handler);
+  }, [internal, debounce, onChange]);
+
+  return (
+    <input
+      type="text"
+      value={internal}
+      onChange={(e) => setInternal(e.target.value)}
+      placeholder="Buscar..."
+      aria-label="Buscar"
+      className="border border-[color:var(--border)] rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[color:var(--primary)]"
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --bg: #f7f8fb;
+  --bg-card: #ffffff;
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --primary: #3b82f6;
+  --primary-600: #2563eb;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --border: #e5e7eb;
+  --radius: 12px;
+  --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  --gap: 16px;
+}
+
+body {
+  @apply bg-[color:var(--bg)] text-[color:var(--text)] font-sans;
+}

--- a/src/pages/Delegaciones.tsx
+++ b/src/pages/Delegaciones.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { Column } from '../components/DataTable';
 import RecordView from '../components/RecordView';
 import ModalDelegacionForm, { DelegacionForm } from '../components/ModalDelegacionForm';
+import PageHeader from '../components/PageHeader';
+import ActionBar from '../components/ActionBar';
+import EmptyState from '../components/EmptyState';
 
 interface Delegacion {
   nombre: string;
@@ -14,43 +17,68 @@ export default function Delegaciones() {
     { nombre: 'Delegación Norte', contacto: 'Carlos' },
   ]);
   const [editing, setEditing] = useState<number | null>(null);
+  const [search, setSearch] = useState('');
+  const [view, setView] = useState<'table' | 'cards'>('table');
+
+  const filtered = delegaciones.filter((d) =>
+    d.nombre.toLowerCase().includes(search.toLowerCase())
+  );
 
   const columns: Column<Delegacion>[] = [
     { key: 'nombre', header: 'Nombre' },
     { key: 'contacto', header: 'Contacto' },
   ];
 
+  const openNew = () => {
+    setEditing(null);
+    setOpen(true);
+  };
+
+  const renderNewButton = () => (
+    <button
+      className="bg-[color:var(--primary)] text-white px-3 py-1 rounded"
+      onClick={openNew}
+    >
+      Nueva delegación
+    </button>
+  );
+
   return (
     <div>
-      <div className="flex justify-between mb-4">
-        <h1 className="text-2xl font-bold">Delegaciones</h1>
-        <button
-          className="bg-blue-500 text-white px-3 py-1 rounded"
-          onClick={() => {
-            setEditing(null);
+      <PageHeader title="Delegaciones" count={filtered.length} view={view} />
+      <ActionBar
+        search={search}
+        onSearch={setSearch}
+        view={view}
+        onViewChange={setView}
+        actions={renderNewButton()}
+      />
+      {filtered.length === 0 ? (
+        <EmptyState
+          title="Aún no hay delegaciones"
+          description="Crea tu primera delegación para empezar a organizar la liga"
+          action={renderNewButton()}
+        />
+      ) : (
+        <RecordView
+          columns={columns}
+          data={filtered}
+          onEdit={(_, idx) => {
+            setEditing(idx);
             setOpen(true);
           }}
-        >
-          Nueva delegación
-        </button>
-      </div>
-      <RecordView
-        columns={columns}
-        data={delegaciones}
-        onEdit={(_, idx) => {
-          setEditing(idx);
-          setOpen(true);
-        }}
-        onDelete={(_, idx) =>
-          setDelegaciones((prev) => prev.filter((_, i) => i !== idx))
-        }
-        cardRender={(d) => (
-          <div>
-            <div className="font-bold">{d.nombre}</div>
-            <div>{d.contacto}</div>
-          </div>
-        )}
-      />
+          onDelete={(_, idx) =>
+            setDelegaciones((prev) => prev.filter((_, i) => i !== idx))
+          }
+          cardRender={(d) => (
+            <div>
+              <div className="font-bold">{d.nombre}</div>
+              <div>{d.contacto}</div>
+            </div>
+          )}
+          view={view}
+        />
+      )}
       <ModalDelegacionForm
         open={open}
         onClose={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- add design tokens and base styles
- introduce reusable PageHeader, ActionBar, SearchInput and EmptyState components
- refactor Delegaciones page with search, view toggle and empty state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf444969c8325bf6462d4bc9b4199