### PR TITLE
Fix Pages deploy workflow with latest artifact action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ jobs:
           test -f index.html
           grep -q "initializeApp(" js/firebase.js
           grep -q "berumen-sports" js/firebase.js
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: .
       - uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- use `actions/upload-pages-artifact@v4` in deploy workflow to avoid deprecated `upload-artifact`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa97c466248325831e714331bd6746