### PR TITLE
Fix Firestore temporada document path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,7 @@ service cloud.firestore {
         allow read: if isSignedIn();
         allow write: if isAdmin() && request.resource.data.ligaId == 'BERUMEN' && request.resource.data.categoria >= 2009 && request.resource.data.categoria <= 2020;
       }
-      match /temporada {
+      match /temporada/{tempId} {
         allow read: if isSignedIn();
         allow write: if isAdmin();
       }

--- a/js/auth.js
+++ b/js/auth.js
@@ -26,7 +26,7 @@ export async function ensureUserProfile(user = auth.currentUser) {
 }
 
 export async function ensureTemporada() {
-  const ref = doc(db, `ligas/${LIGA_ID}/temporada`);
+  const ref = doc(db, `ligas/${LIGA_ID}/temporada/${TEMP_ID}`);
   const snap = await getDoc(ref);
   if (!snap.exists()) {
     await setDoc(ref, {

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -52,7 +52,7 @@ export async function runDiag() {
   } else {
     console.log("Sin usuario autenticado");
   }
-  const tempDoc = await getDoc(doc(db, `ligas/${LIGA_ID}/temporada`));
+  const tempDoc = await getDoc(doc(db, `ligas/${LIGA_ID}/temporada/${TEMP_ID}`));
   console.log("Temporada existe:", tempDoc.exists());
   const delegaciones = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/delegaciones`));
   const equipos = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/equipos`));


### PR DESCRIPTION
## Summary
- Ensure temporada document uses a valid path including TEMP_ID
- Update diagnostic helper to read from the corrected temporada document path
- Adjust Firestore rules to allow temporada documents by ID

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a46e6f48325ac8c7e1d1129c8be