### PR TITLE
Only create temporada document for admin users

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -48,10 +48,13 @@ export function watchAuth(cb) {
   return onAuthStateChanged(auth, async (user) => {
     let profile = null;
     if (user) {
-      await ensureTemporada();
       await ensureUserProfile(user);
-      const snap = await getDoc(doc(db, `ligas/${LIGA_ID}/usuarios/${user.uid}`));
+      const userRef = doc(db, `ligas/${LIGA_ID}/usuarios/${user.uid}`);
+      const snap = await getDoc(userRef);
       profile = snap.data();
+      if (profile?.role === 'admin') {
+        await ensureTemporada();
+      }
     }
     currentProfile = profile;
     cb(user, profile);


### PR DESCRIPTION
## Summary
- Avoid Firebase permission errors by only creating temporada when the authenticated user has the admin role

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9b58dd908325a969d863d975e86a