### PR TITLE
Add placeholder option for delegacion select

### DIFF
--- a/js/views/equipos.js
+++ b/js/views/equipos.js
@@ -34,7 +34,9 @@ export default {
     if(admin){
       const delegSel = qs('select[name="delegacionId"]', form);
       const delegs = await listDelegaciones();
-      delegSel.innerHTML = delegs.map(d=>`<option value="${d.id}">${d.nombre}</option>`).join('');
+      // Add a placeholder option so the browser validation works as expected
+      delegSel.innerHTML = `<option value="" disabled selected>Selecciona una delegación</option>` +
+        delegs.map(d=>`<option value="${d.id}">${d.nombre}</option>`).join('');
       qs('#addEquipo', root)?.addEventListener('click',()=>{form.reset();qs('#modalTitle',root).textContent='Nuevo equipo';modal.classList.add('open');});
       qs('#cancelEq', root).addEventListener('click',()=>modal.classList.remove('open'));
       form.addEventListener('submit', async e=>{


### PR DESCRIPTION
## Summary
- add placeholder item to the delegación select so the browser validation only passes when a real delegación is chosen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2cbad088325ba92ce06bd7e920a