### PR TITLE
Guard admin rule against unauthenticated access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,10 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function isSignedIn() { return request.auth != null; }
-    function isAdmin() { return get(/databases/$(database)/documents/ligas/BERUMEN/usuarios/$(request.auth.uid)).data.role == 'admin'; }
+    function isAdmin() {
+      return request.auth != null &&
+             get(/databases/$(database)/documents/ligas/BERUMEN/usuarios/$(request.auth.uid)).data.role == 'admin';
+    }
 
     match /ligas/BERUMEN {      
       allow read: if isSignedIn();


### PR DESCRIPTION
## Summary
- Avoid invalid Firestore path lookups by ensuring `isAdmin` runs only for signed-in users

## Testing
- `firebase --version` *(fails: command not found)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa405f5e88325be5e960a9a20bb5b