### PR TITLE
Fix appendChild error when rendering numeric nodes

### DIFF
--- a/js/ui-kit.js
+++ b/js/ui-kit.js
@@ -8,7 +8,7 @@ export const el = (tag, attrs={}, children=[]) => {
   });
   (Array.isArray(children)?children:[children]).forEach(c => {
     if(c==null) return;
-    if(typeof c === 'string') element.appendChild(document.createTextNode(c));
+    if(typeof c === 'string' || typeof c === 'number') element.appendChild(document.createTextNode(c));
     else element.appendChild(c);
   });
   return element;


### PR DESCRIPTION
## Summary
- Handle numeric child nodes in `el` utility to avoid `appendChild` TypeError

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaad5776948325a1557cf6a2562a59