### PR TITLE
Improve desktop responsiveness

### DIFF
--- a/css/berumen.css
+++ b/css/berumen.css
@@ -48,6 +48,7 @@ img{max-width:100%;display:block;}
 @media(min-width:768px){.grid-2\@md{grid-template-columns:repeat(2,1fr);} .hide\@md{display:none!important;} .show\@md{display:initial!important;}}
 
 .topbar{position:sticky;top:0;z-index:10;height:var(--topbar-h);display:flex;align-items:center;padding:0 16px;background:rgba(255,255,255,.8);backdrop-filter:blur(10px);border-bottom:1px solid var(--border);box-shadow:0 1px 2px rgba(0,0,0,.04);}
+.topbar .inner{display:flex;align-items:center;width:100%;gap:8px;}
 .topbar-title{font-size:18px;font-weight:600;flex:1;text-align:center;}
 .topbar-user{display:flex;align-items:center;gap:8px;}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:4px;padding:0 16px;height:36px;border-radius:8px;border:1px solid transparent;background:var(--primary);color:#fff;font-weight:500;cursor:pointer;transition:background .16s,transform .16s,box-shadow .16s;}

--- a/css/desktop-fixes.css
+++ b/css/desktop-fixes.css
@@ -40,16 +40,16 @@
     z-index: 40;
     display: block !important; /* forzar visible aunque JS ponga hidden en móvil */
   }
-  .sidedrawer .nav{
+  .sidedrawer nav{
     padding: 12px;
   }
 
   /* Contenido: ancho máximo, centrado, con margen izquierdo para sidebar */
   #app{
     max-width: var(--page-max);
-    margin: 0 auto;
-    padding: var(--gutter);
     margin-left: calc(var(--sidebar-w) + var(--gutter));
+    margin-right: var(--gutter);
+    padding: var(--gutter);
     min-height: calc(100vh - 64px);
   }
 

--- a/index.html
+++ b/index.html
@@ -11,14 +11,16 @@
 </head>
 <body>
   <header class="topbar">
-    <button id="menu-btn" class="btn-icon menu-button" aria-label="Menú">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-    <h1 class="topbar-title">Berumen Sports • Liga 2025</h1>
-    <div class="topbar-user">
-      <span id="user-role" class="badge"></span>
-      <span id="user-email" class="truncate"></span>
-      <button id="logout-btn" class="btn btn-danger btn-xs">Salir</button>
+    <div class="inner">
+      <button id="menu-btn" class="btn-icon menu-button" aria-label="Menú">
+        <span class="material-symbols-outlined">menu</span>
+      </button>
+      <h1 class="topbar-title">Berumen Sports • Liga 2025</h1>
+      <div class="topbar-user">
+        <span id="user-role" class="badge"></span>
+        <span id="user-email" class="truncate"></span>
+        <button id="logout-btn" class="btn btn-danger btn-xs">Salir</button>
+      </div>
     </div>
   </header>
   <aside class="sidedrawer" hidden>


### PR DESCRIPTION
## Summary
- Wrap top bar content in an inner container for better desktop layout
- Fix #app margins and sidedrawer styling to display correctly on large screens
- Add base styles for the new top bar wrapper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aab0f893c08325ac9c593dd89095f1