### PR TITLE
fix: ajustar diseño de escritorio

### DIFF
--- a/css/berumen.css
+++ b/css/berumen.css
@@ -80,8 +80,11 @@ img{max-width:100%;display:block;}
 .sidedrawer{position:fixed;top:0;left:0;bottom:0;width:260px;background:var(--card);border-right:1px solid var(--border);padding:16px;box-shadow:var(--shadow);transform:translateX(-100%);transition:transform .2s;z-index:20;}
 .sidedrawer.open{transform:translateX(0);} 
 .sidedrawer nav a{display:block;padding:12px 8px;border-radius:8px;color:var(--text);} 
-.sidedrawer nav a:hover{background:rgba(0,0,0,.05);} 
-@media(min-width:1024px){.sidedrawer{transform:none;position:static;width:200px;box-shadow:none;border:none;} body{display:grid;grid-template-columns:200px 1fr;} .tabbar{display:none;}}
+.sidedrawer nav a:hover{background:rgba(0,0,0,.05);}
+@media(min-width:1024px){
+  .sidedrawer{transform:none;position:static;width:200px;box-shadow:none;border:none;}
+  .tabbar{display:none;}
+}
 
 .input, .select, textarea{width:100%;height:44px;padding:0 12px;border:1px solid var(--border);border-radius:8px;background:var(--card);color:var(--text);} 
 .input:focus, .select:focus, textarea:focus{outline:2px solid var(--ring);border-color:var(--primary);} 


### PR DESCRIPTION
## Summary
- evitar que el body use grid en escritorio para que el header y la sidebar se acomoden correctamente

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab62d005a0832599a519e9245f3dfd