### PR TITLE
fix: adjust layout for tablet widths

### DIFF
--- a/css/berumen.css
+++ b/css/berumen.css
@@ -81,8 +81,8 @@ img{max-width:100%;display:block;}
 .sidedrawer.open{transform:translateX(0);} 
 .sidedrawer nav a{display:block;padding:12px 8px;border-radius:8px;color:var(--text);} 
 .sidedrawer nav a:hover{background:rgba(0,0,0,.05);}
-@media(min-width:1024px){
-  .sidedrawer{transform:none;position:static;width:200px;box-shadow:none;border:none;}
+@media(min-width:768px){
+  .sidedrawer{transform:none;position:static;width:280px;box-shadow:none;border:none;}
   .tabbar{display:none;}
 }
 

--- a/css/desktop-fixes.css
+++ b/css/desktop-fixes.css
@@ -1,10 +1,10 @@
-/* -------- Berumen Sports • Desktop layout fixes (≥1024px) -------- */
+/* -------- Berumen Sports • Layout fixes for tablet & desktop (≥768px) -------- */
 :root{
   --page-max: 1200px;
   --sidebar-w: 280px;
   --gutter: 24px;
 }
-@media (min-width:1024px){
+@media (min-width:768px){
 
   /* Topbar: centrada y con ancho máximo */
   .topbar{

--- a/js/desktop-layout.js
+++ b/js/desktop-layout.js
@@ -1,7 +1,8 @@
 // Sin dependencias. Sin tocar lógica de datos.
-// 1) Añade/quita una clase en <html> para desktop y 2) asegura que la sidebar quede visible en desktop.
+// 1) Añade/quita una clase en <html> para layouts de pantalla grande
+//    y 2) asegura que la sidebar quede visible en esas vistas.
 (function(){
-  const mq = window.matchMedia('(min-width:1024px)');
+  const mq = window.matchMedia('(min-width:768px)');
   const drawer = () => document.querySelector('.sidedrawer');
 
   function apply(e){
@@ -9,7 +10,7 @@
     const d = drawer();
     if(!d) return;
     if(e.matches){
-      // En desktop siempre visible (aunque el JS móvil haya puesto hidden)
+      // En pantallas amplias siempre visible (aunque el JS móvil haya puesto hidden)
       d.removeAttribute('hidden');
       d.style.display = 'block';
     }


### PR DESCRIPTION
## Summary
- extend desktop layout CSS and JS to tablets so sidebar remains visible
- update base styles to match new tablet breakpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64a5002c8325b46d418e57084489