### PR TITLE
Hide sidebar when not authenticated on desktop

### DIFF
--- a/js/desktop-layout.js
+++ b/js/desktop-layout.js
@@ -5,16 +5,26 @@
   const mq = window.matchMedia('(min-width:768px)');
   const drawer = () => document.querySelector('.sidedrawer');
 
-  function apply(e){
-    document.documentElement.classList.toggle('is-desktop', e.matches);
+  function apply(){
+    const isDesktop = mq.matches;
+    document.documentElement.classList.toggle('is-desktop', isDesktop);
     const d = drawer();
     if(!d) return;
-    if(e.matches){
-      // En pantallas amplias siempre visible (aunque el JS móvil haya puesto hidden)
+    const isAuth = document.body.classList.contains('auth');
+    if(isDesktop && isAuth){
+      // En pantallas amplias la barra lateral debe estar visible
       d.removeAttribute('hidden');
       d.style.display = 'block';
+    } else {
+      // Ocultar para usuarios sin sesión o en pantallas pequeñas
+      d.setAttribute('hidden','');
+      d.style.display = '';
+      d.classList.remove('open');
     }
   }
+
   mq.addEventListener ? mq.addEventListener('change', apply) : mq.addListener(apply);
-  apply(mq);
+  const observer = new MutationObserver(apply);
+  observer.observe(document.body,{attributes:true, attributeFilter:['class']});
+  apply();
 })();


### PR DESCRIPTION
## Summary
- Hide desktop sidebar for users not logged in
- Reapply layout on auth or viewport changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6a6a2f608325bf5663ac11f14294