### PR TITLE
Fix sidebar alignment in desktop view

### DIFF
--- a/css/desktop-fixes.css
+++ b/css/desktop-fixes.css
@@ -33,10 +33,10 @@
 
   /* Sidebar: fija a la izquierda para usuarios autenticados */
   body.auth .sidedrawer{
-    position: sticky !important;
+    position: fixed;
     top: 64px;
     left: 0;
-    width: var(--sidebar-w) !important;
+    width: var(--sidebar-w);
     height: calc(100vh - 64px);
     transform: none !important;
     box-shadow: none !important;


### PR DESCRIPTION
## Summary
- fix desktop sidebar positioning so main content sits beside it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e179dcc832597d1192cc55c7748