### PR TITLE
feat: introduce light/dark theme system

### DIFF
--- a/css/berumen-desktop.css
+++ b/css/berumen-desktop.css
@@ -1,0 +1,10 @@
+/* Desktop layout y densidad (≥1024px) */
+:root{ --sidebar-w: 280px; --gutter: 24px; --container: 1200px; }
+@media (min-width:1024px){
+  .topbar .inner{ max-width: var(--container); margin:0 auto; padding:0 var(--gutter); }
+  .sidedrawer{ position: sticky !important; top:64px; width: var(--sidebar-w) !important; height: calc(100vh - 64px); transform:none !important; display:block !important; }
+  #app{ max-width: var(--container); margin:0 auto; padding: var(--gutter); margin-left: calc(var(--sidebar-w) + var(--gutter)); min-height: calc(100vh - 64px); }
+  .tabbar{ display:none !important; }
+  .btn{ height:36px; padding-inline:14px; } .btn-icon{ width:36px; height:36px; }
+  .card{ padding:16px; }
+}

--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -1,0 +1,118 @@
+/* Berumen Sports • Design Tokens + Global Reset (Light/Dark) */
+:root {
+  color-scheme: light dark;
+  --font: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  /* Light */
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --primary: #2563eb;        --primary-600: #1d4ed8; --primary-700: #1e40af;
+  --success: #10b981;        --warning: #f59e0b;     --danger: #ef4444;
+  --border: #e2e8f0;         --ring: rgba(37,99,235,.35);
+  --shadow: 0 10px 30px rgba(2,6,23,.08);
+  --radius: 14px;
+  --container: 1120px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Dark */
+    --bg: #0b1220;
+    --surface: #0f172a;
+    --text: #e5e7eb;
+    --muted: #94a3b8;
+    --border: #1f2937;
+    --shadow: 0 20px 50px rgba(0,0,0,.25);
+  }
+}
+/* Forzar tema con data-theme si se requiere */
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"]  { color-scheme: dark;  --bg:#0b1220; --surface:#0f172a; --text:#e5e7eb; --muted:#94a3b8; --border:#1f2937; --shadow:0 20px 50px rgba(0,0,0,.25); }
+
+/* Reset básico y herencia de color */
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0; font-family: var(--font);
+  background: var(--bg); color: var(--text);
+  -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+}
+img, svg, video { display:block; max-width:100%; }
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+h1,h2,h3,h4,h5,h6 { color: var(--text); margin: 0 0 .5rem; }
+h1 { font-size: clamp(20px, 2.2vw, 28px); line-height:1.2; }
+h2 { font-size: clamp(18px, 1.8vw, 24px); line-height:1.25; }
+p, label, th, td, input, select, button, small { color: var(--text); }
+.text-muted { color: var(--muted) !important; }
+
+/* Container y layout base */
+.container { width:100%; max-width: var(--container); margin: 0 auto; padding: 0 16px; }
+@media (min-width:1024px){ .container { padding: 0 24px; } }
+.card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius); box-shadow: var(--shadow); padding: 16px;
+}
+.section-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin: 10px 0 14px; }
+
+/* Topbar */
+.topbar { position: sticky; top:0; z-index:50; backdrop-filter: saturate(140%) blur(8px); border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 80%, transparent); }
+.topbar .inner { display:grid; grid-template-columns: auto 1fr auto; gap:12px; align-items:center; height:56px; }
+@media (min-width:1024px){ .topbar .inner { height:64px; } }
+
+/* Sidebar / Tabbar */
+.sidedrawer { background: var(--surface); border-right:1px solid var(--border); }
+.tabbar { background: var(--surface); border-top:1px solid var(--border); }
+.tabbar .tab { color: var(--muted); }
+.tabbar .tab[aria-current="page"] { color: var(--primary); background: color-mix(in srgb, var(--primary) 10%, transparent); }
+
+/* Botones */
+.btn { display:inline-flex; align-items:center; justify-content:center; gap:8px; height:44px; padding:0 16px; border-radius:12px; border:1px solid var(--border); background: var(--surface); color: var(--text); transition: .16s ease; }
+.btn:hover { background: color-mix(in srgb, var(--surface) 92%, #000 8%); }
+.btn:focus-visible { outline: 0; box-shadow: 0 0 0 3px var(--ring); }
+.btn:disabled { opacity:.55; cursor:not-allowed; }
+.btn-primary { background: var(--primary); color:#fff; border-color: var(--primary-600); }
+.btn-primary:hover { background: var(--primary-600); }
+.btn-danger { background: var(--danger); color:#fff; border-color: #dc2626; }
+.btn-ghost { background: transparent; border-color: transparent; }
+.btn-icon { width:44px; height:44px; padding:0; }
+
+/* Inputs */
+.input, .select, .textarea {
+  width:100%; height:44px; border:1px solid var(--border); background: var(--surface); color: var(--text);
+  border-radius: 12px; padding: 0 12px; transition: .16s;
+}
+.input::placeholder { color: color-mix(in srgb, var(--muted) 70%, transparent); }
+.input:focus, .select:focus, .textarea:focus { outline:0; box-shadow: 0 0 0 3px var(--ring); border-color: var(--primary); }
+.textarea { height:auto; min-height: 96px; padding: 10px 12px; }
+
+/* Tablas responsive */
+.table-wrap{ overflow:auto; border-radius:12px; border:1px solid var(--border); background: var(--surface); }
+table{ width:100%; border-collapse:collapse; }
+thead th{
+  position: sticky; top:0; z-index:1; text-align:left;
+  background: color-mix(in srgb, var(--surface) 94%, #000 6%);
+  color: var(--text); border-bottom:1px solid var(--border); padding:12px 14px; font-weight:600; font-size:14px;
+}
+tbody td{ padding:12px 14px; border-bottom:1px solid var(--border); color: var(--text); }
+tbody tr:hover{ background: color-mix(in srgb, var(--surface) 96%, #000 4%); }
+.table-stack { display:grid; gap:12px; }
+.table-stack .row { border:1px solid var(--border); border-radius:12px; background:var(--surface); padding:12px; }
+@media (min-width:768px){ .table-stack{ display:block; } }
+
+/* Modales / Sheets */
+.modal-overlay{ position:fixed; inset:0; background: rgba(0,0,0,.45); z-index:80; display:none; }
+.modal{ position:fixed; inset:auto 0 0 0; margin:auto; width:min(720px, calc(100% - 32px)); background:var(--surface); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); padding:16px; z-index:90; display:none; }
+.modal.open, .modal-overlay.open { display:block; }
+@media (min-width:768px){ .modal{ inset: 50% auto auto 50%; transform: translate(-50%,-50%); } }
+
+/* Estados */
+.badge { display:inline-flex; align-items:center; height:22px; padding:0 8px; border-radius:999px; font-size:12px; color:#fff; }
+.badge.admin{ background: var(--primary); } .badge.consulta{ background: var(--muted); }
+.empty{ display:grid; place-items:center; text-align:center; gap:8px; padding:24px; border:1px dashed var(--border); border-radius:12px; color:var(--muted); }
+
+/* Utilidades */
+.hidden{ display:none !important; }
+.text-truncate{ white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.stack{ display:grid; gap:16px; }
+.stack-sm{ display:grid; gap:8px; }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <title>Berumen Sports • Liga 2025</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
   <link rel="stylesheet" href="./css/berumen.css" />
+  <link rel="stylesheet" href="./css/berumen-theme.css">
+  <link rel="stylesheet" href="./css/berumen-desktop.css">
 </head>
 <body>
   <header class="topbar">
@@ -45,6 +47,14 @@
   <div id="modal-root"></div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
+  <script type="module" src="./js/theme-toggle.js"></script>
+  <script type="module">
+    import { enhanceView } from './js/ui-apply.js';
+    const app = document.getElementById('app');
+    function patch(){ enhanceView(app); }
+    window.addEventListener('hashchange', patch);
+    document.addEventListener('DOMContentLoaded', patch);
+  </script>
   <script type="module" src="./js/app.js"></script>
   <noscript>Necesitas habilitar JavaScript para usar esta aplicación.</noscript>
 </body>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,14 @@
+// Opcional: toggle manual de tema si quisieras un switch en "Más"
+// Por defecto respeta prefers-color-scheme.
+export function setTheme(mode /* 'light' | 'dark' | 'system' */){
+  const r = document.documentElement;
+  if(mode === 'light') r.setAttribute('data-theme','light');
+  else if(mode === 'dark') r.setAttribute('data-theme','dark');
+  else r.removeAttribute('data-theme'); // system
+  localStorage.setItem('themeMode', mode);
+}
+export function initTheme(){
+  const saved = localStorage.getItem('themeMode');
+  if(saved) setTheme(saved);
+}
+initTheme();

--- a/js/ui-apply.js
+++ b/js/ui-apply.js
@@ -1,0 +1,18 @@
+// Hook visual: 1) envolver tablas en .table-wrap  2) asegurar headers
+export function enhanceView(root=document){
+  root.querySelectorAll('table').forEach(t=>{
+    if(!t.parentElement.classList.contains('table-wrap')){
+      const wrap = document.createElement('div');
+      wrap.className = 'table-wrap';
+      t.parentNode.insertBefore(wrap, t); wrap.appendChild(t);
+    }
+  });
+  root.querySelectorAll('h1').forEach(h=>{
+    if(!h.closest('.section-header')){
+      const w = document.createElement('div'); w.className='section-header';
+      h.parentNode.insertBefore(w, h); w.appendChild(h);
+      const next = w.nextElementSibling;
+      if(next && next.classList.contains('btn-row')) w.appendChild(next);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add design tokens and global styles for light and dark modes
- support desktop layout with responsive sidebar
- add theme toggle helper and automatic view enhancements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7276a53883259eaea200ac5c5a0e