### PR TITLE
feat: add admin row action buttons

### DIFF
--- a/css/actions.css
+++ b/css/actions.css
@@ -1,0 +1,21 @@
+/* Berumen • Row actions (móvil + desktop) */
+.actions { display:flex; align-items:center; gap:8px; }
+.cell-actions { white-space:nowrap; text-align:right; }
+.action-btn {
+  --bg: color-mix(in srgb, var(--surface, #fff) 92%, #000 8%);
+  --bd: var(--border, #e2e8f0);
+  display:inline-flex; align-items:center; justify-content:center;
+  height:36px; width:36px; border-radius:10px; border:1px solid var(--bd);
+  background: var(--bg); color: var(--text, #0f172a); cursor:pointer;
+  transition: background .16s ease, transform .04s ease;
+}
+.action-btn:hover { background: color-mix(in srgb, var(--surface, #fff) 88%, #000 12%); }
+.action-btn:active { transform: translateY(1px); }
+.action-btn--edit { color:#2563eb; border-color: color-mix(in srgb, #2563eb 30%, var(--bd)); }
+.action-btn--delete { color:#ef4444; border-color: color-mix(in srgb, #ef4444 30%, var(--bd)); }
+.action-btn[disabled] { opacity:.5; cursor:not-allowed; }
+.actions--card { justify-content:flex-end; margin-top:8px; }
+/* en tablas, agrega una columna Acciones (desktop) */
+@media (min-width:768px){
+  th.th-actions { width: 120px; text-align:right; }
+}

--- a/index.html
+++ b/index.html
@@ -5,10 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="icon" href="./img/favicon.ico" />
   <title>Berumen Sports • Liga 2025</title>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@300..700" rel="stylesheet">
   <link rel="stylesheet" href="./css/berumen.css" />
   <link rel="stylesheet" href="./css/berumen-theme.css">
   <link rel="stylesheet" href="./css/berumen-desktop.css">
+  <link rel="stylesheet" href="./css/actions.css">
 </head>
 <body>
   <header class="topbar">

--- a/js/row-actions.js
+++ b/js/row-actions.js
@@ -1,0 +1,104 @@
+// Berumen • utilidades para inyectar acciones Editar/Eliminar en cualquier listado.
+// Uso: after render de una vista, llama a injectRowActions({...})
+import { userRole } from './firebase-ui.js'; // función que devuelve "admin"|"consulta" (ajusta si tu helper tiene otro nombre)
+
+/**
+ * @typedef {Object} ActionsOptions
+ * @property {HTMLElement} root            - contenedor donde buscar filas
+ * @property {string} rowSelector          - selector de cada item con data-id (ej: 'tbody tr[data-id], .table-stack .row[data-id]')
+ * @property {(p:{id:string,el:HTMLElement})=>void} onEdit
+ * @property {(p:{id:string,el:HTMLElement})=>Promise<void>|void} onDelete
+ * @property {('table'|'card'|'auto')} [mode]  - cómo renderizar (auto detecta)
+ * @property {boolean} [onlyAdmin=true]        - si true, solo muestra a admins
+ */
+export function injectRowActions(opts){
+  const role = (typeof userRole === 'function' ? userRole() : 'consulta');
+  const onlyAdmin = opts.onlyAdmin !== false;
+  if (onlyAdmin && role !== 'admin') return; // no muestra nada a consulta
+
+  const root = opts.root || document;
+  const rows = root.querySelectorAll(opts.rowSelector);
+  if (!rows.length) return;
+
+  rows.forEach(el=>{
+    const id = el.getAttribute('data-id');
+    if (!id || el.querySelector('[data-actions]')) return; // ya tiene acciones
+    const isTableRow = el.tagName === 'TR' || el.closest('table');
+    const mode = opts.mode || (isTableRow ? 'table' : 'card');
+
+    if (mode === 'table') {
+      // Cabecera: asegura th "Acciones"
+      const table = el.closest('table');
+      if (table && !table.querySelector('thead th.th-actions')) {
+        const th = document.createElement('th');
+        th.className = 'th-actions'; th.textContent = 'Acciones';
+        const theadRow = table.tHead?.rows[0];
+        if (theadRow) theadRow.appendChild(th);
+      }
+      // Celda de acciones
+      const td = document.createElement('td');
+      td.className = 'cell-actions'; td.setAttribute('data-actions','');
+      td.appendChild(makeBtn('edit', 'Editar'));
+      td.appendChild(makeBtn('delete', 'Eliminar'));
+      el.appendChild(td);
+    } else {
+      // Card / lista apilada
+      const footer = document.createElement('div');
+      footer.className = 'actions actions--card'; footer.setAttribute('data-actions','');
+      footer.appendChild(makeBtn('edit', 'Editar'));
+      footer.appendChild(makeBtn('delete', 'Eliminar'));
+      el.appendChild(footer);
+    }
+  });
+
+  // Delegación de eventos (un solo listener)
+  root.addEventListener('click', async (ev)=>{
+    const btn = ev.target.closest('[data-action]');
+    if (!btn) return;
+    const host = btn.closest('[data-id]');
+    if (!host) return;
+    const id = host.getAttribute('data-id');
+    if (!id) return;
+
+    const type = btn.getAttribute('data-action');
+    if (type === 'edit') {
+      opts.onEdit?.({ id, el: host });
+    } else if (type === 'delete') {
+      // Confirmación simple + bloqueo mientras elimina
+      if (!(await confirmDelete(host.getAttribute('data-name') || 'registro'))) return;
+      btn.setAttribute('disabled', 'true');
+      try {
+        await opts.onDelete?.({ id, el: host });
+        // Si el handler no removió la fila, lo hacemos aquí
+        const isRow = host.tagName === 'TR';
+        if (isRow) host.remove();
+        else host.classList.add('hidden');
+      } finally {
+        btn.removeAttribute('disabled');
+      }
+    }
+  }, { once: false });
+
+  function makeBtn(kind, label){
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = `action-btn action-btn--${kind}`;
+    b.setAttribute('title', label);
+    b.setAttribute('aria-label', label);
+    b.setAttribute('data-action', kind);
+    // icono Material Symbols
+    const i = document.createElement('span');
+    i.className = 'material-symbols-outlined';
+    i.textContent = kind === 'edit' ? 'edit' : 'delete';
+    b.appendChild(i);
+    return b;
+  }
+}
+
+/** Confirmación accesible minimal */
+export function confirmDelete(name='registro'){
+  return new Promise(res=>{
+    const ok = window.confirm(`¿Eliminar ${name}? Esta acción no se puede deshacer.`);
+    res(ok);
+  });
+}

--- a/js/ui-kit.js
+++ b/js/ui-kit.js
@@ -79,7 +79,7 @@ export function renderResponsiveTable(container, config){
     if(window.innerWidth<768){
       const list=el('div',{class:'table-stack'});
       config.rows.forEach(row=>{
-        const card=el('div',{class:'row'});
+        const card=el('div',{class:'row','data-id':row.id,'data-name':row.nombre||row.equipo||row.local||''});
         config.columns.forEach(col=>{
           const v=col.format?col.format(row[col.key]):row[col.key];
           card.appendChild(el('div',{},[el('strong',{},col.label+': '), el('span',{},v)]));
@@ -112,7 +112,7 @@ export function renderResponsiveTable(container, config){
             }
             return el('td',{},(c.format?c.format(row[c.key]):row[c.key]));
           });
-          return el('tr',{},tds);
+          return el('tr',{'data-id':row.id,'data-name':row.nombre||row.equipo||row.local||''},tds);
         }))
       ]);
       container.appendChild(table);

--- a/js/views/cobros.js
+++ b/js/views/cobros.js
@@ -1,15 +1,17 @@
-import { db, collection, getDocs, addDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from '../firebase-ui.js';
 import { el, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
 export async function render(){
   const section=el('section',{class:'stack'});
   section.appendChild(el('h2',{},'Cobros'));
   const container=el('div',{class:'stack'}); section.appendChild(container);
+  let rows=[];
 
   async function load(){
     const snap=await getDocs(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros`));
-    const rows=snap.docs.map(d=>({id:d.id,...d.data()}));
+    rows=snap.docs.map(d=>({id:d.id,...d.data()}));
     if(!rows.length){
       container.innerHTML='';
       container.appendChild(emptyState({icon:'payments',title:'Sin cobros',body:'',action:null}));
@@ -17,18 +19,52 @@ export async function render(){
     }
     container.innerHTML='';
     rows.forEach(row=>{
-      container.appendChild(el('div',{class:'card stack-sm'},[
-        el('h3',{},row.equipo||'Equipo'),
-        el('p',{},`Monto: $${row.monto||0}`),
+      container.appendChild(el('div',{class:'card stack-sm','data-id':row.id,'data-name':row.equipo||row.equipoNombre||''},[
+        el('h3',{},row.equipo||row.equipoNombre||'Equipo'),
+        el('p',{},`Monto: $${row.monto||row.montoTotal||0}`),
         el('p',{},`Saldo: $${row.saldo||0}`),
         el('button',{class:'btn btn-primary btn-xs',onClick:()=>openAbono(row)},'Registrar abono')
       ]));
     });
+    injectRowActions({
+      root: container,
+      rowSelector: 'div.card[data-id]',
+      onEdit: ({id})=>openEdit(id),
+      onDelete: ({id})=>remove(id)
+    });
+  }
+
+  function openForm(row){
+    const form=el('form',{class:'stack'},[
+      el('label',{},['Equipo', el('input',{class:'input',name:'equipo',required:true,value:row?.equipo||row?.equipoNombre||''})]),
+      el('label',{},['Monto', el('input',{class:'input',type:'number',name:'monto',required:true,value:row?.monto||row?.montoTotal||0})]),
+      el('label',{},['Saldo', el('input',{class:'input',type:'number',name:'saldo',required:true,value:row?.saldo||0})]),
+      el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
+    ]);
+    form.addEventListener('submit', async e=>{
+      e.preventDefault();
+      const data=readForm(form);
+      data.monto=Number(data.monto); data.saldo=Number(data.saldo);
+      const btn=form.querySelector('button'); setBusy(btn,true);
+      try{
+        if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros/${row.id}`), {equipo:data.equipo,monto:data.monto,saldo:data.saldo}); }
+        else{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros`), {equipo:data.equipo,monto:data.monto,saldo:data.saldo}); }
+        closeModal(); load(); showToast('success','Guardado');
+      }catch(err){ showToast('error',err.message); } finally{ setBusy(btn,false); }
+    });
+    openSheet(row?'Editar cobro':'Nuevo cobro',form);
+  }
+
+  const openEdit = id=>{ const row=rows.find(r=>r.id===id); if(row) openForm(row); };
+
+  async function remove(id){
+    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros/${id}`)); showToast('success','Eliminado'); load(); }
+    catch(err){ showToast('error',err.message); }
   }
 
   function openAbono(row){
     const form=el('form',{class:'stack'},[
-      el('p',{},row.equipo),
+      el('p',{},row.equipo||row.equipoNombre||''),
       el('label',{},['Monto', el('input',{class:'input',type:'number',name:'monto',min:1,max:row.saldo,required:true})]),
       el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
     ]);

--- a/js/views/delegaciones.js
+++ b/js/views/delegaciones.js
@@ -1,5 +1,6 @@
-import { db, collection, getDocs, addDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
 import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID } from '../constants.js';
 
 export async function render(){
@@ -21,11 +22,17 @@ export async function render(){
       return;
     }
     renderResponsiveTable(container,{columns:[{key:'nombre',label:'Nombre'}],rows});
+    injectRowActions({
+      root: container,
+      rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
+      onEdit: ({id})=>openEdit(id),
+      onDelete: ({id})=>remove(id)
+    });
   }
 
-  function openNew(){
+  function openForm(row){
     const form = el('form',{class:'stack'},[
-      el('label',{},['Nombre', el('input',{class:'input',name:'nombre',required:true})]),
+      el('label',{},['Nombre', el('input',{class:'input',name:'nombre',required:true,value:row?.nombre||''})]),
       el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
     ]);
     form.addEventListener('submit', async e=>{
@@ -33,11 +40,27 @@ export async function render(){
       const data=readForm(form);
       const btn=form.querySelector('button');
       setBusy(btn,true);
-      try{ await addDoc(collection(db,`ligas/${LIGA_ID}/delegaciones`), data); closeModal(); load(); showToast('success','Guardado'); }
+      try{
+        if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/delegaciones/${row.id}`), data); }
+        else{ await addDoc(collection(db,`ligas/${LIGA_ID}/delegaciones`), data); }
+        closeModal(); load(); showToast('success','Guardado');
+      }
       catch(err){ showToast('error',err.message); }
       finally{ setBusy(btn,false); }
     });
-    openSheet('Nueva delegación',form);
+    openSheet(row?'Editar delegación':'Nueva delegación',form);
+  }
+
+  const openNew = () => openForm(null);
+
+  async function openEdit(id){
+    const snap = await getDoc(doc(db,`ligas/${LIGA_ID}/delegaciones/${id}`));
+    if(snap.exists()) openForm({id:snap.id,...snap.data()});
+  }
+
+  async function remove(id){
+    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/delegaciones/${id}`)); showToast('success','Eliminado'); load(); }
+    catch(err){ showToast('error',err.message); }
   }
 
   header.querySelector('#newBtn').addEventListener('click',openNew);

--- a/js/views/equipos.js
+++ b/js/views/equipos.js
@@ -1,5 +1,6 @@
-import { db, collection, getDocs, addDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
 import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID } from '../constants.js';
 
 export async function render(){
@@ -21,12 +22,18 @@ export async function render(){
       return;
     }
     renderResponsiveTable(container,{columns:[{key:'nombre',label:'Nombre'},{key:'delegacion',label:'Delegación'}],rows});
+    injectRowActions({
+      root: container,
+      rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
+      onEdit: ({id})=>openEdit(id),
+      onDelete: ({id})=>remove(id)
+    });
   }
 
-  function openNew(){
+  function openForm(row){
     const form = el('form',{class:'stack'},[
-      el('label',{},['Nombre', el('input',{class:'input',name:'nombre',required:true})]),
-      el('label',{},['Delegación', el('input',{class:'input',name:'delegacion',required:true})]),
+      el('label',{},['Nombre', el('input',{class:'input',name:'nombre',required:true,value:row?.nombre||''})]),
+      el('label',{},['Delegación', el('input',{class:'input',name:'delegacion',required:true,value:row?.delegacion||''})]),
       el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
     ]);
     form.addEventListener('submit', async e=>{
@@ -34,11 +41,26 @@ export async function render(){
       const data=readForm(form);
       const btn=form.querySelector('button');
       setBusy(btn,true);
-      try{ await addDoc(collection(db,`ligas/${LIGA_ID}/equipos`), data); closeModal(); load(); showToast('success','Guardado'); }
-      catch(err){ showToast('error',err.message); }
+      try{
+        if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/equipos/${row.id}`), data); }
+        else{ await addDoc(collection(db,`ligas/${LIGA_ID}/equipos`), data); }
+        closeModal(); load(); showToast('success','Guardado');
+      }catch(err){ showToast('error',err.message); }
       finally{ setBusy(btn,false); }
     });
-    openSheet('Nuevo equipo',form);
+    openSheet(row?'Editar equipo':'Nuevo equipo',form);
+  }
+
+  const openNew = () => openForm(null);
+
+  async function openEdit(id){
+    const snap = await getDoc(doc(db,`ligas/${LIGA_ID}/equipos/${id}`));
+    if(snap.exists()) openForm({id:snap.id,...snap.data()});
+  }
+
+  async function remove(id){
+    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/equipos/${id}`)); showToast('success','Eliminado'); load(); }
+    catch(err){ showToast('error',err.message); }
   }
 
   header.querySelector('#newBtn').addEventListener('click',openNew);

--- a/js/views/partidos.js
+++ b/js/views/partidos.js
@@ -1,5 +1,6 @@
-import { db, collection, getDocs, addDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
 import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
 export async function render(){
@@ -20,23 +21,44 @@ export async function render(){
       return;
     }
     renderResponsiveTable(container,{columns:[{key:'fecha',label:'Fecha'},{key:'local',label:'Local'},{key:'visitante',label:'Visitante'}],rows});
+    injectRowActions({
+      root: container,
+      rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
+      onEdit: ({id})=>openEdit(id),
+      onDelete: ({id})=>remove(id)
+    });
   }
 
-  function openNew(){
+  function openForm(row){
     const form=el('form',{class:'stack'},[
-      el('label',{},['Fecha', el('input',{class:'input',type:'date',name:'fecha',required:true})]),
-      el('label',{},['Local', el('input',{class:'input',name:'local',required:true})]),
-      el('label',{},['Visitante', el('input',{class:'input',name:'visitante',required:true})]),
+      el('label',{},['Fecha', el('input',{class:'input',type:'date',name:'fecha',required:true,value:row?.fecha||''})]),
+      el('label',{},['Local', el('input',{class:'input',name:'local',required:true,value:row?.local||''})]),
+      el('label',{},['Visitante', el('input',{class:'input',name:'visitante',required:true,value:row?.visitante||''})]),
       el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
     ]);
     form.addEventListener('submit', async e=>{
       e.preventDefault();
       const data=readForm(form);
       const btn=form.querySelector('button'); setBusy(btn,true);
-      try{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos`), data); closeModal(); load(); showToast('success','Guardado'); }
-      catch(err){showToast('error',err.message);} finally{setBusy(btn,false);}
+      try{
+        if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos/${row.id}`), data); }
+        else{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos`), data); }
+        closeModal(); load(); showToast('success','Guardado');
+      }catch(err){showToast('error',err.message);} finally{setBusy(btn,false);}
     });
-    openSheet('Nuevo partido', form);
+    openSheet(row?'Editar partido':'Nuevo partido', form);
+  }
+
+  const openNew = ()=>openForm(null);
+
+  async function openEdit(id){
+    const snap = await getDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos/${id}`));
+    if(snap.exists()) openForm({id:snap.id,...snap.data()});
+  }
+
+  async function remove(id){
+    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos/${id}`)); showToast('success','Eliminado'); load(); }
+    catch(err){ showToast('error',err.message); }
   }
 
   header.querySelector('#newBtn').addEventListener('click',openNew);

--- a/js/views/tarifas.js
+++ b/js/views/tarifas.js
@@ -1,5 +1,6 @@
 import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from '../firebase-ui.js';
 import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal, confirmDialog } from '../ui-kit.js';
+import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
 export async function render(){
@@ -10,16 +11,23 @@ export async function render(){
   ]);
   section.appendChild(header);
   const container=el('div'); section.appendChild(container);
+  let rows=[];
 
   async function load(){
     const snap=await getDocs(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas`));
-    const rows=snap.docs.map(d=>({id:d.id,...d.data()}));
+    rows=snap.docs.map(d=>({id:d.id,...d.data()}));
     if(!rows.length){
       container.innerHTML='';
       container.appendChild(emptyState({icon:'price_check',title:'Sin tarifas',body:'',action:{label:'Crear',onClick:openNew}}));
       return;
     }
-    renderResponsiveTable(container,{columns:[{key:'rama',label:'Rama'},{key:'categoria',label:'Categoría'},{key:'monto',label:'Monto',format:v=>`$${v}`}],rows,actions:[{icon:'edit',label:'Editar',onClick:openEdit},{icon:'delete',label:'Eliminar',onClick:remove}]});
+    renderResponsiveTable(container,{columns:[{key:'rama',label:'Rama'},{key:'categoria',label:'Categoría'},{key:'monto',label:'Monto',format:v=>`$${v}`}],rows});
+    injectRowActions({
+      root: container,
+      rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
+      onEdit: ({id})=>openEdit(id),
+      onDelete: ({id})=>remove(id)
+    });
   }
 
   function openForm(row){
@@ -46,12 +54,12 @@ export async function render(){
   }
 
   const openNew = ()=>openForm(null);
-  const openEdit = row=>openForm(row);
+  const openEdit = id=>{ const row=rows.find(r=>r.id===id); if(row) openForm(row); };
 
-  async function remove(row){
+  async function remove(id){
     const ok = await confirmDialog({body:'¿Eliminar tarifa?',confirmText:'Eliminar'});
     if(!ok) return;
-    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas/${row.id}`)); showToast('success','Eliminado'); load(); }
+    try{ await deleteDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas/${id}`)); showToast('success','Eliminado'); load(); }
     catch(err){ showToast('error',err.message); }
   }
 


### PR DESCRIPTION
## Summary
- add shared `injectRowActions` utility and styles
- wire action buttons into list views for delegaciones, equipos, partidos, tarifas y cobros
- load Material Symbols font and actions.css

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab74e650ac8325939b55261481d4b6