### PR TITLE
Fix bottom tab navigation routing and accessibility

### DIFF
--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -64,7 +64,7 @@ p, label, th, td, input, select, button, small { color: var(--text); }
 .sidedrawer { background: var(--surface); border-right:1px solid var(--border); }
 .tabbar { background: var(--surface); border-top:1px solid var(--border); }
 .tabbar .tab { color: var(--muted); }
-.tabbar .tab[aria-current="page"] { color: var(--primary); background: color-mix(in srgb, var(--primary) 10%, transparent); }
+.tabbar .tab[aria-selected="true"] { color: var(--primary); background: color-mix(in srgb, var(--primary) 10%, transparent); }
 
 /* Botones */
 .btn { display:inline-flex; align-items:center; justify-content:center; gap:8px; height:44px; padding:0 16px; border-radius:12px; border:1px solid var(--border); background: var(--surface); color: var(--text); transition: .16s ease; }

--- a/css/berumen.css
+++ b/css/berumen.css
@@ -39,6 +39,7 @@ button,input,select{font-family:inherit;font-size:1rem;line-height:1.5;}
 img{max-width:100%;display:block;}
 
 .container{max-width:1120px;margin:0 auto;padding:0 16px;}
+.auth #app{padding-bottom:calc(var(--tabbar-h) + env(safe-area-inset-bottom));}
 .hide{display:none!important;}
 .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .stack{display:flex;flex-direction:column;gap:16px;}
@@ -72,9 +73,10 @@ body:not(.auth) #menu-btn,body:not(.auth) .topbar-user,body:not(.auth) .sidedraw
 
 .actions{display:flex;gap:4px;}
 .actions .btn-icon{width:32px;height:32px;}
-.tabbar{position:fixed;bottom:0;left:0;right:0;height:var(--tabbar-h);display:flex;background:var(--card);border-top:1px solid var(--border);}
-.tabbar a{flex:1;text-align:center;font-size:10px;color:var(--muted);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;}
-.tabbar a.active{color:var(--primary);background:rgba(37,99,235,.08);}
+.tabbar{position:fixed;bottom:0;left:0;right:0;height:var(--tabbar-h);display:flex;background:var(--card);border-top:1px solid var(--border);padding-bottom:env(safe-area-inset-bottom);}
+.tabbar .tab{flex:1;text-align:center;font-size:10px;color:var(--muted);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;min-height:44px;}
+.tabbar .tab[aria-selected="true"]{color:var(--primary);background:rgba(37,99,235,.08);}
+.tabbar.disabled{pointer-events:none;}
 .tabbar .material-symbols-outlined{font-size:22px;}
 
 .sidedrawer{position:fixed;top:0;left:0;bottom:0;width:260px;background:var(--card);border-right:1px solid var(--border);padding:16px;box-shadow:var(--shadow);transform:translateX(-100%);transition:transform .2s;z-index:20;}

--- a/index.html
+++ b/index.html
@@ -38,12 +38,12 @@
     </nav>
   </aside>
   <main id="app" class="container"></main>
-  <nav class="tabbar">
-    <a href="#/" data-tab="home"><span class="material-symbols-outlined">home</span><span class="tab-label">Inicio</span></a>
-    <a href="#/partidos" data-tab="partidos"><span class="material-symbols-outlined">sports</span><span class="tab-label">Partidos</span></a>
-    <a href="#/equipos" data-tab="equipos"><span class="material-symbols-outlined">groups</span><span class="tab-label">Equipos</span></a>
-    <a href="#/cobros" data-tab="cobros"><span class="material-symbols-outlined">payments</span><span class="tab-label">Cobros</span></a>
-    <a href="#/more" data-tab="more"><span class="material-symbols-outlined">more_horiz</span><span class="tab-label">Más</span></a>
+  <nav class="tabbar" role="tablist">
+    <a href="#/" class="tab" role="tab" aria-label="Inicio" aria-selected="false"><span class="material-symbols-outlined">home</span><span class="tab-label">Inicio</span></a>
+    <a href="#/partidos" class="tab" role="tab" aria-label="Partidos" aria-selected="false"><span class="material-symbols-outlined">sports</span><span class="tab-label">Partidos</span></a>
+    <a href="#/equipos" class="tab" role="tab" aria-label="Equipos" aria-selected="false"><span class="material-symbols-outlined">groups</span><span class="tab-label">Equipos</span></a>
+    <a href="#/cobros" class="tab" role="tab" aria-label="Cobros" aria-selected="false"><span class="material-symbols-outlined">payments</span><span class="tab-label">Cobros</span></a>
+    <a href="#/mas" class="tab" role="tab" aria-label="Más" aria-selected="false"><span class="material-symbols-outlined">more_horiz</span><span class="tab-label">Más</span></a>
   </nav>
   <div id="toaster"></div>
   <div id="modal-root"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,7 @@ const routes = {
   '#/partidos': () => import('./views/partidos.js'),
   '#/cobros': () => import('./views/cobros.js'),
   '#/reportes': () => import('./views/reportes.js'),
+  '#/mas': () => import('./views/mas.js'),
 };
 
 async function router() {
@@ -20,11 +21,12 @@ async function router() {
     location.hash = path;
   }
   const load = routes[path];
-  const app = qs('#app');
   if (!load) {
-    app.textContent = 'Ruta no encontrada';
+    showToast('error', 'Sección no encontrada');
+    location.hash = '#/';
     return;
   }
+  const app = qs('#app');
   const mod = await load();
   app.innerHTML = '';
   const el = await mod.render();
@@ -40,13 +42,52 @@ function updateNav(path) {
   const topbarUser = qs('.topbar-user');
   const isLogin = path === '#/login';
   if (tabbar) {
-    const tabs = tabbar.querySelectorAll('a');
-    tabs.forEach(t => t.classList.toggle('active', t.getAttribute('href') === path));
+    const tabs = Array.from(tabbar.querySelectorAll('.tab'));
+    tabs.forEach(t => {
+      const active = t.getAttribute('href') === path;
+      t.setAttribute('aria-selected', active);
+      t.tabIndex = active ? 0 : -1;
+    });
     tabbar.classList.toggle('hide', isLogin);
+    tabbar.classList.remove('disabled');
   }
   if (menuBtn) menuBtn.classList.toggle('hide', isLogin);
   if (drawer) drawer.classList.toggle('hide', isLogin);
   if (topbarUser) topbarUser.classList.toggle('hide', isLogin);
+}
+
+function initTabbar() {
+  const tabbar = qs('.tabbar');
+  if (!tabbar) return;
+  const tabs = Array.from(tabbar.querySelectorAll('.tab'));
+  tabs.forEach((t,i)=> t.tabIndex = i===0 ? 0 : -1);
+
+  tabbar.addEventListener('click', (e) => {
+    const tab = e.target.closest('.tab');
+    if (!tab) return;
+    e.preventDefault();
+    if (tab.getAttribute('aria-selected') === 'true') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    tabbar.classList.add('disabled');
+    location.hash = tab.getAttribute('href');
+  });
+
+  tabbar.addEventListener('keydown', (e) => {
+    const current = document.activeElement.closest('.tab');
+    const idx = tabs.indexOf(current);
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      let next = e.key === 'ArrowRight' ? idx + 1 : idx - 1;
+      if (next < 0) next = tabs.length - 1;
+      if (next >= tabs.length) next = 0;
+      tabs[next].focus();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      current?.click();
+    }
+  });
 }
 
 function initMenu() {
@@ -106,4 +147,5 @@ window.addEventListener('hashchange', router);
 
 initMenu();
 initLogout();
+initTabbar();
 router();

--- a/js/views/mas.js
+++ b/js/views/mas.js
@@ -1,0 +1,8 @@
+import { el } from '../ui-kit.js';
+
+export async function render(){
+  return el('section',{class:'stack'},[
+    el('h2',{},'Más'),
+    el('p',{},'Sección en construcción.')
+  ]);
+}


### PR DESCRIPTION
## Summary
- Align bottom tab bar with canonical routes and add placeholder `Más` view
- Improve tab navigation: active state, keyboard support, scroll-to-top and safe-area handling
- Redirect unknown hashes to home and sync tab bar state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab775699448325ac76f7071fe177a4