### PR TITLE
feat: persist auth session and restore navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,17 @@
-import { auth, onAuthChanged, signOut, userRole } from './firebase-ui.js';
+import { auth, onAuthChanged, signOut, userRole, ensureUserProfile, ensureTemporada } from './firebase-ui.js';
 import { qs, showToast } from './ui-kit.js';
 import { enhanceView } from './views/_shared-patches.js';
+
+const AUTH = {
+  UNKNOWN: 'desconocido',
+  AUTHENTICATED: 'autenticado',
+  NOT_AUTHENTICATED: 'noAutenticado'
+};
+
+let authState = AUTH.UNKNOWN;
+let routerLocked = true;
+const app = qs('#app');
+app.innerHTML = '<p class="loading">Cargando...</p>';
 
 const routes = {
   '#/': () => import('./views/dashboard.js'),
@@ -14,11 +25,27 @@ const routes = {
   '#/mas': () => import('./views/mas.js'),
 };
 
+function getSavedRoute() {
+  const r = localStorage.getItem('lastRoute');
+  return r && r !== '#/login' && routes[r] ? r : '#/';
+}
+
 async function router() {
+  if (authState === AUTH.UNKNOWN) return;
   let path = location.hash || '#/';
-  if (!auth.currentUser && path !== '#/login') {
-    path = '#/login';
-    location.hash = path;
+  if (authState === AUTH.NOT_AUTHENTICATED) {
+    if (path !== '#/login') {
+      location.hash = '#/login';
+      return;
+    }
+  } else if (authState === AUTH.AUTHENTICATED) {
+    if (path === '#/login') {
+      const target = getSavedRoute();
+      if (target !== path) {
+        location.hash = target;
+        return;
+      }
+    }
   }
   const load = routes[path];
   if (!load) {
@@ -26,7 +53,6 @@ async function router() {
     location.hash = '#/';
     return;
   }
-  const app = qs('#app');
   const mod = await load();
   app.innerHTML = '';
   const el = await mod.render();
@@ -126,26 +152,37 @@ function initLogout() {
 }
 
 onAuthChanged(async (user) => {
-  document.body.classList.toggle('auth', !!user);
   const roleEl = qs('#user-role');
   const emailEl = qs('#user-email');
   if (user) {
+    await ensureUserProfile();
+    await ensureTemporada();
+    authState = AUTH.AUTHENTICATED;
     emailEl.textContent = user.email || '';
     const role = await userRole();
     roleEl.textContent = role;
     roleEl.classList.add(role);
-    router();
   } else {
+    authState = AUTH.NOT_AUTHENTICATED;
     emailEl.textContent = '';
     roleEl.textContent = '';
     roleEl.className = 'badge';
+  }
+  document.body.classList.toggle('auth', authState === AUTH.AUTHENTICATED);
+  routerLocked = false;
+  const target = authState === AUTH.AUTHENTICATED ? getSavedRoute() : '#/login';
+  if (location.hash !== target) {
+    location.hash = target;
+  } else {
     router();
   }
 });
 
-window.addEventListener('hashchange', router);
+window.addEventListener('hashchange', () => {
+  localStorage.setItem('lastRoute', location.hash);
+  if (!routerLocked) router();
+});
 
 initMenu();
 initLogout();
 initTabbar();
-router();

--- a/js/firebase-ui.js
+++ b/js/firebase-ui.js
@@ -4,7 +4,9 @@ import {
   onAuthStateChanged,
   signOut as fbSignOut,
   signInWithEmailAndPassword,
-  createUserWithEmailAndPassword
+  createUserWithEmailAndPassword,
+  setPersistence,
+  browserLocalPersistence
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 import {
   getFirestore,
@@ -32,6 +34,8 @@ const firebaseConfig = {
 
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+// Persist authentication between tabs and reloads
+setPersistence(auth, browserLocalPersistence);
 export const db = getFirestore(app);
 
 export const signOut = () => fbSignOut(auth);

--- a/js/views/login.js
+++ b/js/views/login.js
@@ -16,7 +16,6 @@ export async function render(){
     setBusy(btn,true);
     try{
       await signInWithEmailAndPassword(auth,data.email,data.password);
-      location.hash = '#/'
     }catch(err){
       showToast('error', err.message);
     }finally{


### PR DESCRIPTION
## Summary
- ensure Firebase Auth persistence using browser local storage
- gate routes behind explicit auth state and restore last visited path
- let login rely on auth gate by removing manual redirect

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79b75d248325918b29634be41237