### PR TITLE
feat: force mobile layout on iPad

### DIFF
--- a/css/actions.css
+++ b/css/actions.css
@@ -9,13 +9,13 @@
   background: var(--bg); color: var(--text, #0f172a); cursor:pointer;
   transition: background .16s ease, transform .04s ease;
 }
-.action-btn:hover { background: color-mix(in srgb, var(--surface, #fff) 88%, #000 12%); }
+html:not(.is-mobile) .action-btn:hover { background: color-mix(in srgb, var(--surface, #fff) 88%, #000 12%); }
 .action-btn:active { transform: translateY(1px); }
 .action-btn--edit { color:#2563eb; border-color: color-mix(in srgb, #2563eb 30%, var(--bd)); }
 .action-btn--delete { color:#ef4444; border-color: color-mix(in srgb, #ef4444 30%, var(--bd)); }
 .action-btn[disabled] { opacity:.5; cursor:not-allowed; }
 .actions--card { justify-content:flex-end; margin-top:8px; }
 /* en tablas, agrega una columna Acciones (desktop) */
-@media (min-width:768px){
-  th.th-actions { width: 120px; text-align:right; }
+@media (pointer: fine) and (min-width:768px){
+  html:not(.is-mobile) th.th-actions { width: 120px; text-align:right; }
 }

--- a/css/berumen-desktop.css
+++ b/css/berumen-desktop.css
@@ -1,10 +1,11 @@
 /* Desktop layout y densidad (≥1024px) */
 :root{ --sidebar-w: 280px; --gutter: 24px; --container: 1200px; }
-@media (min-width:1024px){
-  .topbar .inner{ max-width: var(--container); margin:0 auto; padding:0 var(--gutter); }
-  .sidedrawer{ position: sticky !important; top:64px; width: var(--sidebar-w) !important; height: calc(100vh - 64px); transform:none !important; display:block !important; }
-  #app{ max-width: var(--container); margin:0 auto; padding: var(--gutter); margin-left: calc(var(--sidebar-w) + var(--gutter)); min-height: calc(100vh - 64px); }
-  .tabbar{ display:none !important; }
-  .btn{ height:36px; padding-inline:14px; } .btn-icon{ width:36px; height:36px; }
-  .card{ padding:16px; }
+@media (pointer: fine) and (min-width:1024px){
+  html:not(.is-mobile) .topbar .inner{ max-width: var(--container); margin:0 auto; padding:0 var(--gutter); }
+  html:not(.is-mobile) .sidedrawer{ position: sticky !important; top:64px; width: var(--sidebar-w) !important; height: calc(var(--vh, 1vh) * 100 - 64px); transform:none !important; display:block !important; }
+  html:not(.is-mobile) #app{ max-width: var(--container); margin:0 auto; padding: var(--gutter); margin-left: calc(var(--sidebar-w) + var(--gutter)); min-height: calc(var(--vh, 1vh) * 100 - 64px); }
+  html:not(.is-mobile) .tabbar{ display:none !important; }
+  html:not(.is-mobile) .btn{ height:36px; padding-inline:14px; }
+  html:not(.is-mobile) .btn-icon{ width:36px; height:36px; }
+  html:not(.is-mobile) .card{ padding:16px; }
 }

--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -39,7 +39,7 @@ body {
 }
 img, svg, video { display:block; max-width:100%; }
 a { color: var(--primary); text-decoration: none; }
-a:hover { text-decoration: underline; }
+html:not(.is-mobile) a:hover { text-decoration: underline; }
 h1,h2,h3,h4,h5,h6 { color: var(--text); margin: 0 0 .5rem; }
 h1 { font-size: clamp(20px, 2.2vw, 28px); line-height:1.2; }
 h2 { font-size: clamp(18px, 1.8vw, 24px); line-height:1.25; }
@@ -48,7 +48,7 @@ p, label, th, td, input, select, button, small { color: var(--text); }
 
 /* Container y layout base */
 .container { width:100%; max-width: var(--container); margin: 0 auto; padding: 0 16px; }
-@media (min-width:1024px){ .container { padding: 0 24px; } }
+@media (pointer: fine) and (min-width:1024px){ html:not(.is-mobile) .container { padding: 0 24px; } }
 .card {
   background: var(--surface); border: 1px solid var(--border);
   border-radius: var(--radius); box-shadow: var(--shadow); padding: 16px;
@@ -58,7 +58,7 @@ p, label, th, td, input, select, button, small { color: var(--text); }
 /* Topbar */
 .topbar { position: sticky; top:0; z-index:50; backdrop-filter: saturate(140%) blur(8px); border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 80%, transparent); }
 .topbar .inner { display:grid; grid-template-columns: auto 1fr auto; gap:12px; align-items:center; height:56px; }
-@media (min-width:1024px){ .topbar .inner { height:64px; } }
+@media (pointer: fine) and (min-width:1024px){ html:not(.is-mobile) .topbar .inner { height:64px; } }
 
 /* Sidebar / Tabbar */
 .sidedrawer { background: var(--surface); border-right:1px solid var(--border); }
@@ -68,11 +68,11 @@ p, label, th, td, input, select, button, small { color: var(--text); }
 
 /* Botones */
 .btn { display:inline-flex; align-items:center; justify-content:center; gap:8px; height:44px; padding:0 16px; border-radius:12px; border:1px solid var(--border); background: var(--surface); color: var(--text); transition: .16s ease; }
-.btn:hover { background: color-mix(in srgb, var(--surface) 92%, #000 8%); }
+html:not(.is-mobile) .btn:hover { background: color-mix(in srgb, var(--surface) 92%, #000 8%); }
 .btn:focus-visible { outline: 0; box-shadow: 0 0 0 3px var(--ring); }
 .btn:disabled { opacity:.55; cursor:not-allowed; }
 .btn-primary { background: var(--primary); color:#fff; border-color: var(--primary-600); }
-.btn-primary:hover { background: var(--primary-600); }
+html:not(.is-mobile) .btn-primary:hover { background: var(--primary-600); }
 .btn-danger { background: var(--danger); color:#fff; border-color: #dc2626; }
 .btn-ghost { background: transparent; border-color: transparent; }
 .btn-icon { width:44px; height:44px; padding:0; }
@@ -95,16 +95,16 @@ thead th{
   color: var(--text); border-bottom:1px solid var(--border); padding:12px 14px; font-weight:600; font-size:14px;
 }
 tbody td{ padding:12px 14px; border-bottom:1px solid var(--border); color: var(--text); }
-tbody tr:hover{ background: color-mix(in srgb, var(--surface) 96%, #000 4%); }
+html:not(.is-mobile) tbody tr:hover{ background: color-mix(in srgb, var(--surface) 96%, #000 4%); }
 .table-stack { display:grid; gap:12px; }
 .table-stack .row { border:1px solid var(--border); border-radius:12px; background:var(--surface); padding:12px; }
-@media (min-width:768px){ .table-stack{ display:block; } }
+@media (pointer: fine) and (min-width:768px){ html:not(.is-mobile) .table-stack{ display:block; } }
 
 /* Modales / Sheets */
 .modal-overlay{ position:fixed; inset:0; background: rgba(0,0,0,.45); z-index:80; display:none; }
 .modal{ position:fixed; inset:auto 0 0 0; margin:auto; width:min(720px, calc(100% - 32px)); background:var(--surface); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); padding:16px; z-index:90; display:none; }
 .modal.open, .modal-overlay.open { display:block; }
-@media (min-width:768px){ .modal{ inset: 50% auto auto 50%; transform: translate(-50%,-50%); } }
+@media (pointer: fine) and (min-width:768px){ html:not(.is-mobile) .modal{ inset: 50% auto auto 50%; transform: translate(-50%,-50%); } }
 
 /* Estados */
 .badge { display:inline-flex; align-items:center; height:22px; padding:0 8px; border-radius:999px; font-size:12px; color:#fff; }

--- a/css/berumen.css
+++ b/css/berumen.css
@@ -46,7 +46,7 @@ img{max-width:100%;display:block;}
 .stack-sm{gap:8px;}
 .stack-lg{gap:24px;}
 .grid-2\@md{display:grid;gap:16px;}
-@media(min-width:768px){.grid-2\@md{grid-template-columns:repeat(2,1fr);} .hide\@md{display:none!important;} .show\@md{display:initial!important;}}
+@media (pointer: fine) and (min-width:768px){html:not(.is-mobile) .grid-2\@md{grid-template-columns:repeat(2,1fr);} html:not(.is-mobile) .hide\@md{display:none!important;} html:not(.is-mobile) .show\@md{display:initial!important;}}
 
 .topbar{position:sticky;top:0;z-index:10;height:var(--topbar-h);display:flex;align-items:center;padding:0 16px;background:rgba(255,255,255,.8);backdrop-filter:blur(10px);border-bottom:1px solid var(--border);box-shadow:0 1px 2px rgba(0,0,0,.04);}
 .topbar .inner{display:flex;align-items:center;width:100%;gap:8px;}
@@ -56,13 +56,13 @@ img{max-width:100%;display:block;}
 @media(max-width:480px){.topbar-user .truncate{display:none;}}
 body:not(.auth) #menu-btn,body:not(.auth) .topbar-user,body:not(.auth) .sidedrawer,body:not(.auth) .tabbar{display:none!important;}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:4px;padding:0 16px;height:36px;border-radius:8px;border:1px solid transparent;background:var(--primary);color:#fff;font-weight:500;cursor:pointer;transition:background .16s,transform .16s,box-shadow .16s;}
-.btn:hover{background:var(--primary-600);}
+html:not(.is-mobile) .btn:hover{background:var(--primary-600);}
 .btn:disabled{opacity:.5;pointer-events:none;}
 .btn-ghost{background:transparent;color:var(--text);}
 .btn-danger{background:var(--danger);}
 .btn-outline{background:transparent;border-color:var(--border);color:var(--text);}
 .btn-icon{width:44px;height:44px;background:transparent;border:none;cursor:pointer;border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
-.btn-icon:hover{background:rgba(0,0,0,.04);} 
+html:not(.is-mobile) .btn-icon:hover{background:rgba(0,0,0,.04);}
 .btn-xs{height:32px;padding:0 8px;font-size:.875rem;}
 
 .badge{padding:2px 8px;border-radius:9999px;font-size:.75rem;background:var(--border);color:var(--text);} 
@@ -82,7 +82,7 @@ body:not(.auth) #menu-btn,body:not(.auth) .topbar-user,body:not(.auth) .sidedraw
 .sidedrawer{position:fixed;top:0;left:0;bottom:0;width:260px;background:var(--card);border-right:1px solid var(--border);padding:16px;box-shadow:var(--shadow);transform:translateX(-100%);transition:transform .2s;z-index:20;}
 .sidedrawer.open{transform:translateX(0);} 
 .sidedrawer nav a{display:block;padding:12px 8px;border-radius:8px;color:var(--text);} 
-.sidedrawer nav a:hover{background:rgba(0,0,0,.05);}
+html:not(.is-mobile) .sidedrawer nav a:hover{background:rgba(0,0,0,.05);}
 
 .input, .select, textarea{width:100%;height:44px;padding:0 12px;border:1px solid var(--border);border-radius:8px;background:var(--card);color:var(--text);} 
 .input:focus, .select:focus, textarea:focus{outline:2px solid var(--ring);border-color:var(--primary);} 
@@ -90,17 +90,17 @@ body:not(.auth) #menu-btn,body:not(.auth) .topbar-user,body:not(.auth) .sidedraw
 .table-stack{display:flex;flex-direction:column;gap:12px;}
 .table-stack .row{position:relative;padding:16px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow);}
 .table-stack .actions{position:absolute;top:8px;right:8px;}
-@media(min-width:768px){.table-stack{display:none;} table{width:100%;border-collapse:collapse;} thead{position:sticky;top:calc(var(--topbar-h));background:var(--card);} th,td{padding:8px 12px;border-bottom:1px solid var(--border);} tbody tr:nth-child(even){background:rgba(0,0,0,.02);} }
+@media (pointer: fine) and (min-width:768px){html:not(.is-mobile) .table-stack{display:none;} html:not(.is-mobile) table{width:100%;border-collapse:collapse;} html:not(.is-mobile) thead{position:sticky;top:calc(var(--topbar-h));background:var(--card);} html:not(.is-mobile) th,html:not(.is-mobile) td{padding:8px 12px;border-bottom:1px solid var(--border);} html:not(.is-mobile) tbody tr:nth-child(even){background:rgba(0,0,0,.02);} }
 
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:30;}
 .modal{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);max-width:720px;width:90%;padding:16px;}
-.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);box-shadow:var(--shadow);max-height:90vh;overflow:auto;padding:16px;animation:slideUp .2s ease-out;z-index:40;}
+.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);box-shadow:var(--shadow);max-height:calc(var(--vh, 1vh) * 90);overflow:auto;padding:16px;animation:slideUp .2s ease-out;z-index:40;}
 @keyframes slideUp{from{transform:translateY(100%);}to{transform:translateY(0);}}
 
 .skeleton{background:linear-gradient(90deg,#e2e8f0,#f8fafc,#e2e8f0);background-size:200% 100%;animation:shimmer 1.2s infinite;}@keyframes shimmer{0%{background-position:200% 0;}100%{background-position:-200% 0;}}
 
 .toast-container{position:fixed;z-index:50;left:50%;transform:translateX(-50%);bottom:16px;display:flex;flex-direction:column;gap:8px;}
-@media(min-width:768px){.toast-container{left:auto;right:16px;transform:none;top:16px;bottom:auto;}}
+@media (pointer: fine) and (min-width:768px){html:not(.is-mobile) .toast-container{left:auto;right:16px;transform:none;top:16px;bottom:auto;}}
 .toast{min-width:200px;padding:12px 16px;border-radius:8px;background:var(--card);border:1px solid var(--border);box-shadow:var(--shadow);display:flex;align-items:center;gap:8px;}
 .toast.success{border-color:var(--success);}
 .toast.warning{border-color:var(--warning);}

--- a/css/nav.css
+++ b/css/nav.css
@@ -6,6 +6,7 @@
   background: var(--surface);
   color: var(--text);
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  padding-top: env(safe-area-inset-top);
 }
 .topbar .inner {
   display: flex;
@@ -20,7 +21,7 @@
   border-radius: .375rem;
   color: inherit;
 }
-.topbar .btn-icon:hover,
+html:not(.is-mobile) .topbar .btn-icon:hover,
 .topbar .btn-icon:focus-visible {
   background: color-mix(in srgb, var(--text) 10%, transparent);
   box-shadow: 0 0 0 2px var(--ring);
@@ -52,7 +53,7 @@
   color: var(--primary);
   background: color-mix(in srgb, var(--primary) 15%, transparent);
 }
-.sidedrawer nav a:hover,
+html:not(.is-mobile) .sidedrawer nav a:hover,
 .sidedrawer nav a:focus-visible {
   background: color-mix(in srgb, var(--text) 10%, transparent);
   outline: none;
@@ -74,14 +75,19 @@
 body.lock-scroll {
   overflow: hidden;
 }
-@media (min-width: 1024px) {
-  .sidedrawer {
+html.is-mobile main#app {
+  padding-bottom: calc(56px + env(safe-area-inset-bottom));
+}
+@media (pointer: fine) and (min-width:1024px) {
+  html:not(.is-mobile) .sidedrawer {
     transform: none;
     position: static;
     width: 220px;
     padding-top: 0;
   }
-  .drawer-overlay { display: none; }
+  html:not(.is-mobile) .drawer-overlay { display: none; }
+  html:not(.is-mobile) .tabbar { display: none; }
+  html:not(.is-mobile) main#app { padding-bottom: 0; }
 }
 
 /* Tabbar */
@@ -110,17 +116,9 @@ body.lock-scroll {
   color: var(--primary);
   background: color-mix(in srgb, var(--primary) 15%, transparent);
 }
-.tabbar .tab:hover,
+html:not(.is-mobile) .tabbar .tab:hover,
 .tabbar .tab:focus-visible {
   background: color-mix(in srgb, var(--text) 10%, transparent);
   outline: none;
   box-shadow: 0 0 0 2px var(--ring);
-}
-@media (min-width: 1024px) {
-  .tabbar { display: none; }
-}
-@media (max-width: 1023px) {
-  main#app {
-    padding-bottom: 56px;
-  }
 }

--- a/index.html
+++ b/index.html
@@ -1,8 +1,23 @@
 <!doctype html>
-<html lang="es">
+<html lang="es" class="is-mobile">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <script>
+    (function () {
+      const root = document.documentElement;
+      function apply() {
+        const coarse = matchMedia('(pointer: coarse)').matches;
+        const touch = navigator.maxTouchPoints >= 1;
+        const fine = matchMedia('(pointer: fine)').matches;
+        const desktop = fine && window.innerWidth >= 1024 && !coarse && !touch;
+        root.classList.toggle('is-mobile', !desktop);
+        root.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+      }
+      ['resize', 'orientationchange'].forEach(ev => window.addEventListener(ev, apply));
+      apply();
+    })();
+  </script>
   <link rel="icon" href="./img/favicon.ico" />
   <title>Berumen Sports • Liga 2025</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600" />

--- a/js/ui-kit.js
+++ b/js/ui-kit.js
@@ -76,7 +76,7 @@ export function closeModal(){
 export function renderResponsiveTable(container, config){
   function render(){
     container.innerHTML='';
-    if(window.innerWidth<768){
+    if(document.documentElement.classList.contains('is-mobile')){
       const list=el('div',{class:'table-stack'});
       config.rows.forEach(row=>{
         const card=el('div',{class:'row','data-id':row.id,'data-name':row.nombre||row.equipo||row.local||''});
@@ -119,7 +119,10 @@ export function renderResponsiveTable(container, config){
     }
   }
   render();
-  window.addEventListener('resize', render, {once:true});
+  if(!container._resizer){
+    container._resizer = () => render();
+    window.addEventListener('resize', container._resizer);
+  }
 }
 
 export function emptyState({icon,title,body,action}){


### PR DESCRIPTION
## Summary
- detect touch capability to toggle `is-mobile` and update `--vh`
- scope desktop rules behind pointer fine + `html:not(.is-mobile)`
- keep tables and nav in mobile style on iPad with safe-area padding

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab925df71c83258001581afe94544f