### PR TITLE
feat: add arbitros management

### DIFF
--- a/css/arbitros.css
+++ b/css/arbitros.css
@@ -1,0 +1,9 @@
+.table-stack .badge{padding:2px 6px;border-radius:4px;font-size:12px;display:inline-block;}
+.badge-activo{background:var(--primary);color:#fff;}
+.badge-inactivo{background:var(--danger);color:#fff;}
+.kpi-chip{display:inline-block;padding:2px 6px;border-radius:12px;font-size:12px;background:var(--surface-variant,#eee);margin-right:4px;}
+.tab-headers{display:flex;gap:4px;margin-bottom:8px;}
+.tab-btn{flex:1;padding:8px;border:none;background:var(--surface,#f5f5f5);}
+.tab-btn.active{background:var(--primary);color:#fff;}
+.tab-panel{display:none;}
+.tab-panel.active{display:block;}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -30,6 +30,24 @@
         {"fieldPath": "fechaEmision", "order": "DESCENDING"}
       ]
     }
+    ,
+    {
+      "collectionGroup": "partidos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "arbitroCentralId", "order": "ASCENDING"},
+        {"fieldPath": "estado", "order": "ASCENDING"},
+        {"fieldPath": "fecha", "order": "DESCENDING"}
+      ]
+    },
+    {
+      "collection": "pagos_arbitros",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "arbitroId", "order": "ASCENDING"},
+        {"fieldPath": "fecha", "order": "DESCENDING"}
+      ]
+    }
   ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,12 @@ service cloud.firestore {
         allow read: if isSignedIn();
         allow write: if isAdmin() && request.resource.data.ligaId == 'BERUMEN' && request.resource.data.categoria >= 2009 && request.resource.data.categoria <= 2020;
       }
+      match /arbitros/{arbitroId} {
+        allow read: if isSignedIn() && ligaId == 'BERUMEN';
+        allow create, update, delete: if isSignedIn() && ligaId == 'BERUMEN' && get(/databases/$(database)/documents/ligas/$(ligaId)/usuarios/$(request.auth.uid)).data.role == 'admin';
+        allow create: if request.resource.data.ligaId == 'BERUMEN' && request.resource.data.nombre is string;
+        allow update: if request.resource.data.ligaId == 'BERUMEN';
+      }
       match /temporada/{tempId} {
         allow read: if isSignedIn();
         allow write: if isAdmin();
@@ -43,6 +49,13 @@ service cloud.firestore {
             allow read: if isSignedIn();
             allow write: if isAdmin() && request.resource.data.ligaId == 'BERUMEN' && request.resource.data.tempId == '2025' && request.resource.data.monto > 0;
           }
+        }
+        match /pagos_arbitros/{pagoId} {
+          allow read: if isSignedIn() && ligaId == 'BERUMEN' && tempId == '2025';
+          allow create: if isSignedIn() && ligaId == 'BERUMEN' && tempId == '2025' &&
+                        get(/databases/$(database)/documents/ligas/$(ligaId)/usuarios/$(request.auth.uid)).data.role == 'admin' &&
+                        request.resource.data.monto > 0 &&
+                        request.resource.data.arbitroId is string;
         }
       }
     }

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="./css/berumen-desktop.css">
   <link rel="stylesheet" href="./css/actions.css">
   <link rel="stylesheet" href="./css/nav.css">
+  <link rel="stylesheet" href="./css/arbitros.css">
 </head>
 <body>
   <header class="topbar" role="banner">
@@ -48,6 +49,7 @@
       <a href="#/partidos">Partidos</a>
       <a href="#/equipos">Equipos</a>
       <a href="#/cobros">Cobros</a>
+      <a href="#/arbitros">Árbitros</a>
       <a href="#/delegaciones">Delegaciones</a>
       <a href="#/tarifas">Tarifas</a>
       <a href="#/reportes">Reportes</a>
@@ -60,6 +62,7 @@
     <a href="#/partidos" class="tab" role="tab" aria-label="Partidos" aria-selected="false"><span class="material-symbols-outlined">sports</span><span class="tab-label">Partidos</span></a>
     <a href="#/equipos" class="tab" role="tab" aria-label="Equipos" aria-selected="false"><span class="material-symbols-outlined">groups</span><span class="tab-label">Equipos</span></a>
     <a href="#/cobros" class="tab" role="tab" aria-label="Cobros" aria-selected="false"><span class="material-symbols-outlined">payments</span><span class="tab-label">Cobros</span></a>
+    <a href="#/arbitros" class="tab" role="tab" aria-label="Árbitros" aria-selected="false"><span class="material-symbols-outlined">sports</span><span class="tab-label">Árbitros</span></a>
     <a href="#/mas" class="tab" role="tab" aria-label="Más" aria-selected="false"><span class="material-symbols-outlined">more_horiz</span><span class="tab-label">Más</span></a>
   </nav>
   <div id="toaster"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -21,6 +21,7 @@ const routes = {
   '#/tarifas': () => import('./views/tarifas.js'),
   '#/partidos': () => import('./views/partidos.js'),
   '#/cobros': () => import('./views/cobros.js'),
+  '#/arbitros': () => import('./views/arbitros.js'),
   '#/reportes': () => import('./views/reportes.js'),
   '#/mas': () => import('./views/mas.js'),
 };

--- a/js/data/arbitros.js
+++ b/js/data/arbitros.js
@@ -1,0 +1,43 @@
+import { db, collection, doc, getDoc, getDocs, addDoc, updateDoc, deleteDoc, query } from "../firebase.js";
+import { serverTimestamp } from "../firebase.js";
+import { buildWhere } from "../utils.js";
+import { LIGA_ID } from "../constants.js";
+
+const L = (p="") => `ligas/${LIGA_ID}/arbitros${p}`;
+
+export async function listArbitros(filters={}){
+  const col = collection(db, L(""));
+  const q = buildWhere(filters);
+  const snap = await getDocs(q.length?query(col, ...q):col);
+  return snap.docs.map(d=>({id:d.id,...d.data()}));
+}
+
+export async function getArbitro(id){
+  const snap = await getDoc(doc(db, L(`/${id}`)));
+  return snap.exists()?{id:snap.id,...snap.data()}:null;
+}
+
+export async function createArbitro(data){
+  if(!data.nombre || !data.nombre.trim()) throw new Error('Nombre requerido');
+  const payload = {
+    nombre: data.nombre.trim(),
+    telefono: data.telefono || "",
+    email: data.email || "",
+    delegacionId: data.delegacionId || "",
+    activo: data.activo !== false,
+    ligaId: LIGA_ID,
+    creadoEn: serverTimestamp(),
+    actualizadoEn: serverTimestamp()
+  };
+  const ref = await addDoc(collection(db, L("")), payload);
+  return ref;
+}
+
+export async function updateArbitro(id, data){
+  data.actualizadoEn = serverTimestamp();
+  await updateDoc(doc(db, L(`/${id}`)), data);
+}
+
+export async function deleteArbitro(id){
+  await deleteDoc(doc(db, L(`/${id}`)));
+}

--- a/js/data/pagos-arbitros.js
+++ b/js/data/pagos-arbitros.js
@@ -1,0 +1,40 @@
+import { db, collection, addDoc, getDocs, query, where, orderBy } from "../firebase.js";
+import { serverTimestamp } from "../firebase.js";
+import { auth } from "../firebase.js";
+import { LIGA_ID, TEMP_ID } from "../constants.js";
+
+const T = (p="") => `ligas/${LIGA_ID}/t/${TEMP_ID}/pagos_arbitros${p}`;
+
+export async function listPagos({arbitroId, desde, hasta}={}){
+  const col = collection(db, T(""));
+  const q = [];
+  if(arbitroId) q.push(where('arbitroId','==',arbitroId));
+  if(desde) q.push(where('fecha','>=',desde));
+  if(hasta) q.push(where('fecha','<=',hasta));
+  q.push(orderBy('fecha','desc'));
+  const snap = await getDocs(q.length?query(col,...q):col);
+  return snap.docs.map(d=>({id:d.id,...d.data()}));
+}
+
+export async function createPago({arbitroId, fecha, monto, metodo, referencia}){
+  const user = auth.currentUser;
+  const data = {
+    arbitroId,
+    fecha,
+    monto: Number(monto),
+    metodo,
+    referencia: referencia || "",
+    usuarioId: user?.uid || "",
+    usuarioEmail: user?.email || "",
+    ligaId: LIGA_ID,
+    tempId: TEMP_ID,
+    creadoEn: serverTimestamp(),
+    actualizadoEn: serverTimestamp()
+  };
+  await addDoc(collection(db, T("")), data);
+}
+
+export async function sumPagos({arbitroId, desde, hasta}={}){
+  const pagos = await listPagos({arbitroId, desde, hasta});
+  return pagos.reduce((s,p)=>s+(p.monto||0),0);
+}

--- a/js/data/partidos-arbitro.js
+++ b/js/data/partidos-arbitro.js
@@ -1,0 +1,19 @@
+import { db, collection, getDocs, query, where, orderBy } from "../firebase.js";
+import { LIGA_ID, TEMP_ID } from "../constants.js";
+
+const T = (p="") => `ligas/${LIGA_ID}/t/${TEMP_ID}/partidos${p}`;
+
+export async function listPartidosDeArbitro({arbitroId, desde, hasta}={}){
+  const col = collection(db, T(""));
+  const q = [where('estado','==','jugado'), where('arbitroCentralId','==', arbitroId)];
+  if(desde) q.push(where('fecha','>=',desde));
+  if(hasta) q.push(where('fecha','<=',hasta));
+  q.push(orderBy('fecha','desc'));
+  const snap = await getDocs(query(col, ...q));
+  return snap.docs.map(d=>({id:d.id,...d.data()}));
+}
+
+export async function sumTarifasDeArbitro({arbitroId, desde, hasta}={}){
+  const partidos = await listPartidosDeArbitro({arbitroId, desde, hasta});
+  return partidos.reduce((s,p)=>s+(p.tarifaAplicada||0),0);
+}

--- a/js/nav.js
+++ b/js/nav.js
@@ -3,6 +3,7 @@ const ROUTES = [
   '#/partidos',
   '#/equipos',
   '#/cobros',
+  '#/arbitros',
   '#/delegaciones',
   '#/tarifas',
   '#/reportes',

--- a/js/router.js
+++ b/js/router.js
@@ -7,6 +7,7 @@ import equiposView from "./views/equipos.js";
 import tarifasView from "./views/tarifas.js";
 import partidosView from "./views/partidos.js";
 import cobrosView from "./views/cobros.js";
+import arbitrosView from "./views/arbitros.js";
 import reportesView from "./views/reportes.js";
 
 const routes = {
@@ -18,6 +19,7 @@ const routes = {
   '/tarifas': tarifasView,
   '/partidos': partidosView,
   '/cobros': cobrosView,
+  '/arbitros': arbitrosView,
   '/reportes': reportesView
 };
 

--- a/js/views/arbitros.js
+++ b/js/views/arbitros.js
@@ -1,0 +1,200 @@
+import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { listArbitros, getArbitro, createArbitro, updateArbitro, deleteArbitro } from '../data/arbitros.js';
+import { listDelegaciones } from '../data/delegaciones.js';
+import { listPagos, createPago, sumPagos } from '../data/pagos-arbitros.js';
+import { listPartidosDeArbitro } from '../data/partidos-arbitro.js';
+import { injectRowActions } from '../row-actions.js';
+import { userRole } from '../firebase-ui.js';
+import { money, formatDate } from '../utils.js';
+
+export async function render(){
+  const role = await userRole();
+  const section = el('section',{class:'stack'});
+  const header = el('div',{class:'stack-sm',style:'flex-direction:row;flex-wrap:wrap;align-items:center;gap:8px;'},[
+    el('h2',{style:'flex:1 1 100%;'},'Árbitros'),
+    el('input',{type:'search',class:'input',id:'search',placeholder:'Buscar'}),
+    el('select',{class:'input',id:'fDeleg'},[el('option',{value:''},'Delegación')]),
+    el('select',{class:'input',id:'fActivo'},[
+      el('option',{value:''},'Estatus'),
+      el('option',{value:'true'},'Activo'),
+      el('option',{value:'false'},'Inactivo')
+    ]),
+    role==='admin'?el('button',{class:'btn btn-primary',id:'newBtn'},'Nuevo árbitro'):null
+  ]);
+  section.appendChild(header);
+  const container = el('div');
+  section.appendChild(container);
+
+  const delegaciones = await listDelegaciones();
+  const sel = header.querySelector('#fDeleg');
+  delegaciones.forEach(d=>sel.appendChild(el('option',{value:d.id},d.nombre)));
+
+  async function load(){
+    const filters={};
+    const q = header.querySelector('#search').value.trim().toLowerCase();
+    const del = header.querySelector('#fDeleg').value;
+    const act = header.querySelector('#fActivo').value;
+    if(del) filters.delegacionId = del;
+    if(act!=='' ) filters.activo = act==='true';
+    let rows = await listArbitros(filters);
+    if(q) rows = rows.filter(r=> (r.nombre||'').toLowerCase().includes(q) || (r.email||'').toLowerCase().includes(q));
+    for(const r of rows){
+      const partidos = await listPartidosDeArbitro({arbitroId:r.id});
+      r.jugados = partidos.length;
+      r.aPagar = partidos.reduce((s,p)=>s+(p.tarifaAplicada||0),0);
+      r.pagado = await sumPagos({arbitroId:r.id});
+      r.saldo = Math.max(0, r.aPagar - r.pagado);
+    }
+    if(!rows.length){
+      container.innerHTML='';
+      container.appendChild(emptyState({icon:'person',title:'Sin árbitros',body:'',action: role==='admin'?{label:'Crear',onClick:openNew}:null}));
+      return;
+    }
+    renderResponsiveTable(container,{
+      columns:[
+        {key:'nombre',label:'Nombre'},
+        {key:'delegacionId',label:'Delegación',format:v=>delegaciones.find(d=>d.id===v)?.nombre||''},
+        {key:'telefono',label:'Teléfono'},
+        {key:'email',label:'Email'},
+        {key:'activo',label:'Estatus',format:v=>v?el('span',{class:'badge badge-activo'},'ACTIVO'):el('span',{class:'badge badge-inactivo'},'INACTIVO')},
+        {key:'jugados',label:'Jugados'},
+        {key:'aPagar',label:'A pagar',format:money},
+        {key:'pagado',label:'Pagado',format:money},
+        {key:'saldo',label:'Saldo',format:money}
+      ],
+      rows,
+      actions: role==='admin'?[{icon:'paid',label:'Liquidar',onClick:(row)=>openPago(row)}]:null
+    });
+    if(role==='admin'){
+      injectRowActions({
+        root: container,
+        rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
+        onEdit: ({id})=>openEdit(id),
+        onDelete: ({id})=>remove(id)
+      });
+    }
+  }
+
+  header.querySelector('#search').addEventListener('input',()=>{clearTimeout(header._t);header._t=setTimeout(load,300);});
+  header.querySelector('#fDeleg').addEventListener('change',load);
+  header.querySelector('#fActivo').addEventListener('change',load);
+  if(role==='admin') header.querySelector('#newBtn').addEventListener('click',openNew);
+
+  container.addEventListener('click',e=>{
+    const row = e.target.closest('[data-id]');
+    if(!row || e.target.closest('[data-actions]')) return;
+    openDetail(row.getAttribute('data-id'));
+  });
+
+  function openForm(row){
+    const form = el('form',{class:'stack'},[
+      el('label',{},['Nombre',el('input',{class:'input',name:'nombre',required:true,value:row?.nombre||''})]),
+      el('label',{},['Teléfono',el('input',{class:'input',name:'telefono',value:row?.telefono||''})]),
+      el('label',{},['Email',el('input',{class:'input',type:'email',name:'email',value:row?.email||''})]),
+      el('label',{},['Delegación',(()=>{const s=el('select',{class:'input',name:'delegacionId'},[el('option',{value:''},'--')]);delegaciones.forEach(d=>s.appendChild(el('option',{value:d.id,selected:d.id===row?.delegacionId},d.nombre)));return s;})()]),
+      el('label',{},[el('input',{type:'checkbox',name:'activo',checked: row?row.activo:true}),' Activo']),
+      el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
+    ]);
+    form.addEventListener('submit',async e=>{
+      e.preventDefault();
+      const data = readForm(form); data.activo = form.activo.checked;
+      const btn=form.querySelector('button'); setBusy(btn,true);
+      try{
+        if(row) await updateArbitro(row.id,data); else await createArbitro(data);
+        closeModal(); showToast('success','Guardado'); load();
+      }catch(err){showToast('error',err.message);}finally{setBusy(btn,false);} 
+    });
+    openSheet(row?'Editar árbitro':'Nuevo árbitro',form);
+  }
+  const openNew=()=>openForm(null);
+  async function openEdit(id){ const r=await getArbitro(id); if(r) openForm(r); }
+  async function remove(id){ try{await deleteArbitro(id);showToast('success','Eliminado');load();}catch(err){showToast('error',err.message);} }
+
+  async function openPago(row){
+    const form = el('form',{class:'stack'},[
+      el('label',{},['Fecha',el('input',{class:'input',type:'date',name:'fecha',value:new Date().toISOString().slice(0,10),required:true})]),
+      el('label',{},['Monto',el('input',{class:'input',type:'number',name:'monto',min:'1',step:'0.01',required:true})]),
+      el('label',{},['Método',el('select',{class:'input',name:'metodo',required:true},[
+        el('option',{value:'efectivo'},'Efectivo'),
+        el('option',{value:'transferencia'},'Transferencia'),
+        el('option',{value:'otros'},'Otros')
+      ])]),
+      el('label',{},['Referencia',el('input',{class:'input',name:'referencia'})]),
+      el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
+    ]);
+    form.addEventListener('submit',async e=>{
+      e.preventDefault();
+      const data = readForm(form);
+      const btn=form.querySelector('button'); setBusy(btn,true);
+      try{
+        await createPago({
+          arbitroId: row.id,
+          fecha: new Date(data.fecha),
+          monto: Number(data.monto),
+          metodo: data.metodo,
+          referencia: data.referencia
+        });
+        closeModal(); showToast('success','Pago registrado'); load();
+      }catch(err){showToast('error',err.message);}finally{setBusy(btn,false);} 
+    });
+    openSheet(`Registrar pago • ${row.nombre}`,form);
+  }
+
+  async function openDetail(id){
+    const arbitro = await getArbitro(id);
+    const [partidos, pagos] = await Promise.all([
+      listPartidosDeArbitro({arbitroId:id}),
+      listPagos({arbitroId:id})
+    ]);
+    const totalDevengar = partidos.reduce((s,p)=>s+(p.tarifaAplicada||0),0);
+    const totalPagado = pagos.reduce((s,p)=>s+(p.monto||0),0);
+    const totalJugados = partidos.length;
+    const saldo = Math.max(0,totalDevengar-totalPagado);
+
+    const resumen = el('div',{class:'stack'},[
+      el('div',{},[`Jugados: ${totalJugados}`]),
+      el('div',{},[`A pagar: ${money(totalDevengar)}`]),
+      el('div',{},[`Pagado: ${money(totalPagado)}`]),
+      el('div',{},[`Saldo: ${money(saldo)}`])
+    ]);
+    const partList = el('ul',{class:'stack'}, partidos.map(p=>
+      el('li',{},`${formatDate(p.fecha?.toDate?p.fecha.toDate():p.fecha)} - ${p.localNombre||''} vs ${p.visitanteNombre||''} (${money(p.tarifaAplicada||0)})`)
+    ));
+    const pagosList = el('ul',{class:'stack'}, pagos.map(p=>
+      el('li',{},`${formatDate(p.fecha)} - ${money(p.monto)} (${p.metodo})`)
+    ));
+
+    const btnRes = el('button',{class:'tab-btn active'},'Resumen');
+    const btnPar = el('button',{class:'tab-btn'},'Partidos');
+    const btnPag = el('button',{class:'tab-btn'},'Pagos');
+    const panelRes = el('div',{class:'tab-panel active'},resumen);
+    const panelPar = el('div',{class:'tab-panel'},partList);
+    const panelPag = el('div',{class:'tab-panel'},pagosList);
+    function setTab(id){
+      btnRes.classList.toggle('active',id==='res');
+      btnPar.classList.toggle('active',id==='par');
+      btnPag.classList.toggle('active',id==='pag');
+      panelRes.classList.toggle('active',id==='res');
+      panelPar.classList.toggle('active',id==='par');
+      panelPag.classList.toggle('active',id==='pag');
+    }
+    btnRes.addEventListener('click',()=>setTab('res'));
+    btnPar.addEventListener('click',()=>setTab('par'));
+    btnPag.addEventListener('click',()=>setTab('pag'));
+    const tabs = el('div',{},[
+      el('div',{class:'tab-headers'},[btnRes,btnPar,btnPag]),
+      panelRes,panelPar,panelPag
+    ]);
+    const content = el('div',{class:'stack'},[
+      el('h3',{},arbitro.nombre||''),
+      tabs,
+      role==='admin'?el('button',{class:'btn btn-primary',onClick:()=>{closeModal();openPago({id:arbitro.id,nombre:arbitro.nombre});}},'Registrar pago'):null
+    ]);
+    openSheet('Detalle árbitro',content);
+  }
+
+  await load();
+  return section;
+}
+
+export default render;


### PR DESCRIPTION
## Summary
- implement árbitros data modules and CRUD UI
- allow registering payments and viewing metrics per árbitro
- integrate new Árbitros section into navigation and Firestore rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab952741388325b045244ee5a061d8