### PR TITLE
feat: add unified modal system

### DIFF
--- a/README_modales.md
+++ b/README_modales.md
@@ -1,0 +1,44 @@
+# Gestor de modales
+
+Este proyecto utiliza un administrador único de modales accesibles.
+
+## API básica
+```js
+import { Modal } from './js/modal-manager.js';
+Modal.init(); // una sola vez
+```
+
+### Abrir
+```js
+Modal.open('#template-id');            // modal centrado o sheet en móvil
+Modal.sheet('#template-id');           // sheet forzado
+Modal.open(nodo, {title:'Título'});    // contenido dinámico
+```
+
+### Cerrar
+```js
+Modal.close();      // cierra el más reciente
+Modal.close(id);    // cierra por id
+Modal.closeAll();
+```
+
+### Eventos
+```js
+Modal.on('open', fn);
+Modal.on('afterOpen', fn);
+Modal.on('beforeClose', fn);
+Modal.on('afterClose', fn);
+```
+
+## Atributos declarativos
+- `[data-modal-open="#id"]` abre un modal.
+- `[data-modal-sheet="#id"]` abre como sheet.
+- `[data-modal-close]` cierra el modal actual.
+
+Los modales deben existir como `<template>` o `<div data-modal-id="...">` para ser descubiertos.
+
+## Buenas prácticas
+- Mantén el contenido principal dentro de `<div id="modal-root"></div>`.
+- Evita listeners duplicados; `Modal.init()` es idempotente.
+- Usa tokens de diseño (`--surface`, `--text`, etc.) para estilos internos.
+- Recuerda que todos los modales se cierran al cambiar de ruta o cerrar sesión.

--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -100,12 +100,6 @@ html:not(.is-mobile) tbody tr:hover{ background: color-mix(in srgb, var(--surfac
 .table-stack .row { border:1px solid var(--border); border-radius:12px; background:var(--surface); padding:12px; }
 @media (pointer: fine) and (min-width:768px){ html:not(.is-mobile) .table-stack{ display:block; } }
 
-/* Modales / Sheets */
-.modal-overlay{ position:fixed; inset:0; background: rgba(0,0,0,.45); z-index:80; display:none; }
-.modal{ position:fixed; inset:auto 0 0 0; margin:auto; width:min(720px, calc(100% - 32px)); background:var(--surface); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); padding:16px; z-index:90; display:none; }
-.modal.open, .modal-overlay.open { display:block; }
-@media (pointer: fine) and (min-width:768px){ html:not(.is-mobile) .modal{ inset: 50% auto auto 50%; transform: translate(-50%,-50%); } }
-
 /* Estados */
 .badge { display:inline-flex; align-items:center; height:22px; padding:0 8px; border-radius:999px; font-size:12px; color:#fff; }
 .badge.admin{ background: var(--primary); } .badge.consulta{ background: var(--muted); }

--- a/css/berumen.css
+++ b/css/berumen.css
@@ -92,10 +92,10 @@ html:not(.is-mobile) .sidedrawer nav a:hover{background:rgba(0,0,0,.05);}
 .table-stack .actions{position:absolute;top:8px;right:8px;}
 @media (pointer: fine) and (min-width:768px){html:not(.is-mobile) .table-stack{display:none;} html:not(.is-mobile) table{width:100%;border-collapse:collapse;} html:not(.is-mobile) thead{position:sticky;top:calc(var(--topbar-h));background:var(--card);} html:not(.is-mobile) th,html:not(.is-mobile) td{padding:8px 12px;border-bottom:1px solid var(--border);} html:not(.is-mobile) tbody tr:nth-child(even){background:rgba(0,0,0,.02);} }
 
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:30;}
-.modal{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);max-width:720px;width:90%;padding:16px;}
-.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);border-top-left-radius:var(--radius);border-top-right-radius:var(--radius);box-shadow:var(--shadow);max-height:calc(var(--vh, 1vh) * 90);overflow:auto;padding:16px;animation:slideUp .2s ease-out;z-index:40;}
-@keyframes slideUp{from{transform:translateY(100%);}to{transform:translateY(0);}}
+
+
+
+to{transform:translateY(0);}}
 
 .skeleton{background:linear-gradient(90deg,#e2e8f0,#f8fafc,#e2e8f0);background-size:200% 100%;animation:shimmer 1.2s infinite;}@keyframes shimmer{0%{background-position:200% 0;}100%{background-position:-200% 0;}}
 

--- a/css/modals.css
+++ b/css/modals.css
@@ -1,0 +1,15 @@
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:80;opacity:0;pointer-events:none;transition:opacity .2s ease;}
+.modal-overlay[data-open]{opacity:1;pointer-events:auto;}
+.modal-overlay[data-closing]{opacity:0;}
+.modal, .sheet{background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);width:90%;max-width:720px;max-height:calc(var(--vh,1vh)*90);display:flex;flex-direction:column;overflow:hidden;}
+.modal{transform:scale(.95);transition:transform .2s ease;}
+.modal-overlay[data-open] .modal{transform:scale(1);}
+.sheet{width:100%;margin-top:auto;border-bottom-left-radius:0;border-bottom-right-radius:0;transform:translateY(100%);transition:transform .25s ease;}
+.modal-overlay[data-open] .sheet{transform:translateY(0);}
+.sheet::before{content:"";width:40px;height:4px;border-radius:2px;background:var(--border);margin:8px auto;}
+.modal-header{display:flex;align-items:center;justify-content:space-between;padding:16px;border-bottom:1px solid var(--border);}
+.modal-body{padding:16px;overflow:auto;flex:1;}
+.modal-footer{padding:16px;border-top:1px solid var(--border);}
+[data-modal-close]{background:none;border:none;padding:4px;}
+.sheet .modal-body{padding-bottom:calc(env(safe-area-inset-bottom) + 16px);}
+body.modal-lock{overflow:hidden;position:fixed;width:100%;}

--- a/css/styles.css
+++ b/css/styles.css
@@ -19,7 +19,7 @@ input,select{padding:.4rem;border:1px solid #ccc;border-radius:.25rem}
 .main{padding:1rem;min-width:0}
 .table{width:100%;border-collapse:collapse}
 .table th,.table td{border:1px solid #ddd;padding:.5rem;text-align:left}
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:20}
-.modal-overlay.open{display:flex}
-.modal{background:#fff;padding:1rem;max-width:500px;width:90%;border-radius:.5rem}
+
+
+
 html,body{padding-bottom:env(safe-area-inset-bottom)}

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   <link rel="stylesheet" href="./css/actions.css">
   <link rel="stylesheet" href="./css/nav.css">
   <link rel="stylesheet" href="./css/arbitros.css">
+  <link rel="stylesheet" href="./css/modals.css">
 </head>
 <body>
   <header class="topbar" role="banner">
@@ -69,6 +70,7 @@
   <div id="modal-root"></div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
+  <script type="module" src="./js/modal-manager.js"></script>
   <script type="module" src="./js/theme-toggle.js"></script>
   <script type="module">
     import { enhanceView } from './js/ui-apply.js';

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,4 @@
+import { Modal } from './modal-manager.js';
 import { auth, onAuthChanged, signOut, userRole, ensureUserProfile, ensureTemporada } from './firebase-ui.js';
 import { qs, showToast } from './ui-kit.js';
 import { enhanceView } from './views/_shared-patches.js';
@@ -12,6 +13,7 @@ const AUTH = {
 let authState = AUTH.UNKNOWN;
 const app = qs('#app');
 app.innerHTML = '<p class="loading">Cargando...</p>';
+Modal.init();
 
 const routes = {
   '#/': () => import('./views/dashboard.js'),
@@ -90,6 +92,7 @@ onAuthChanged(async (user) => {
 });
 
 window.addEventListener('hashchange', () => {
+  Modal.closeAll();
   localStorage.setItem('lastRoute', location.hash);
   router();
 });
@@ -106,6 +109,7 @@ function navigate(route) {
 }
 async function onSignOut() {
   await signOut();
+  Modal.closeAll();
   showToast('success', 'Sesión cerrada');
   navigate('#/login');
 }

--- a/js/modal-manager.js
+++ b/js/modal-manager.js
@@ -1,0 +1,72 @@
+const focusableSel = 'a[href], button:not([disabled]), textarea, input:not([type="hidden"]), select, [tabindex]:not([tabindex="-1"])';
+const defaults = { trapFocus:true, escClose:true, clickOutsideClose:true, preventScroll:true, restoreFocus:true, safeArea:true, destroyOnClose:false };
+const stack = [];
+const listeners = {open:[], afterOpen:[], beforeClose:[], afterClose:[]};
+let initialized=false;
+let lastTrigger=null;
+
+function emit(ev, detail){ (listeners[ev]||[]).forEach(fn=>fn(detail)); }
+
+function lockScroll(){ const y=window.scrollY; document.body.dataset.modalScrollY=y; document.body.style.top=`-${y}px`; document.body.classList.add('modal-lock'); }
+function unlockScroll(){ const y=parseInt(document.body.dataset.modalScrollY||'0',10); document.body.classList.remove('modal-lock'); document.body.style.top=''; window.scrollTo(0,y); delete document.body.dataset.modalScrollY; }
+
+function backgroundInert(on){ const els=[...document.body.children].filter(el=>el.id!=='modal-root'); els.forEach(el=>{ if(on){ el.setAttribute('aria-hidden','true'); el.setAttribute('inert',''); } else{ el.removeAttribute('aria-hidden'); el.removeAttribute('inert'); } }); }
+
+function setupTrap(container){ const focusables=Array.from(container.querySelectorAll(focusableSel)); const first=focusables[0]||container; const last=focusables[focusables.length-1]||container; const start=document.createElement('span'); start.tabIndex=0; const end=document.createElement('span'); end.tabIndex=0; start.className='focus-sentinel'; end.className='focus-sentinel'; start.addEventListener('focus',()=>last.focus()); end.addEventListener('focus',()=>first.focus()); container.prepend(start); container.appendChild(end); container._trap={start,end}; }
+function removeTrap(container){ const t=container._trap; if(t){ t.start.remove(); t.end.remove(); delete container._trap; } }
+
+function handleEsc(e){ if(e.key==='Escape'){ const top=stack[stack.length-1]; if(top && top.options.escClose) close(top.id); }}
+
+document.addEventListener('keydown',handleEsc);
+
+function open(target, options={}){
+  options={...defaults,...options};
+  const isMobile=document.documentElement.classList.contains('is-mobile');
+  const id = typeof target==='string' && target.startsWith('#') ? target.slice(1) : `m${Date.now()}`;
+  let content;
+  if(typeof target==='string'){
+    if(target.startsWith('#')){
+      const tpl=document.getElementById(target.slice(1));
+      if(tpl){ content=tpl.tagName==='TEMPLATE'?tpl.content.cloneNode(true):tpl.cloneNode(true); }
+    } else { const tmp=document.createElement('div'); tmp.innerHTML=target; content=tmp; }
+  } else if(target instanceof Node){ content=target; }
+  const overlay=document.createElement('div'); overlay.className='modal-overlay'; overlay.dataset.modalId=id;
+  const inner=document.createElement('div'); inner.className=options.sheet || isMobile ? 'sheet' : 'modal'; inner.setAttribute('role','dialog'); inner.setAttribute('aria-modal','true');
+  if(options.title){
+    const header=document.createElement('header'); header.className='modal-header';
+    const h=document.createElement('h2'); h.id=`${id}-title`; h.textContent=options.title; header.appendChild(h);
+    const btn=document.createElement('button'); btn.setAttribute('type','button'); btn.className='modal-close'; btn.setAttribute('aria-label','Cerrar'); btn.setAttribute('data-modal-close',''); btn.innerHTML='<span class="material-symbols-outlined">close</span>'; header.appendChild(btn);
+    inner.appendChild(header); inner.setAttribute('aria-labelledby',h.id);
+  }
+  const body=document.createElement('div'); body.className='modal-body'; if(content) body.append(content); inner.appendChild(body);
+  overlay.appendChild(inner);
+  const root=document.getElementById('modal-root')||document.body; root.appendChild(overlay);
+  if(options.preventScroll && stack.length===0){ lockScroll(); backgroundInert(true); }
+  if(options.trapFocus) setupTrap(inner);
+  overlay.addEventListener('click',e=>{ if(e.target===overlay && options.clickOutsideClose) close(id); });
+  setTimeout(()=>overlay.setAttribute('data-open',''));
+  const focusEl=inner.querySelector('[autofocus],'+focusableSel); (focusEl||inner).focus();
+  const opener=options.trigger||document.activeElement; stack.push({id,overlay,inner,options,opener});
+  window.__MODAL_DEBUG__.openStack=stack; emit('open',{id}); setTimeout(()=>emit('afterOpen',{id}),200);
+  return id;
+}
+
+function sheet(target,opts={}){ return open(target,{...opts,sheet:true}); }
+
+function close(id){ let m; if(!id){ m=stack.pop(); } else { const i=stack.findIndex(x=>x.id===id); if(i>=0) m=stack.splice(i,1)[0]; }
+  if(!m) return; emit('beforeClose',{id:m.id}); m.overlay.setAttribute('data-closing',''); setTimeout(()=>{ removeTrap(m.inner); m.overlay.remove(); if(m.options.restoreFocus && m.opener instanceof HTMLElement) m.opener.focus(); if(stack.length===0 && m.options.preventScroll){ unlockScroll(); backgroundInert(false);} emit('afterClose',{id:m.id}); },200);
+}
+
+function closeAll(){ while(stack.length) close(stack[stack.length-1].id); }
+
+function setContent(id, html){ const m=stack.find(x=>x.id===id); if(!m) return; const body=m.inner.querySelector('.modal-body'); body.innerHTML=''; if(typeof html==='string') body.innerHTML=html; else if(html) body.append(html); }
+
+function on(ev,handler){ if(listeners[ev]) listeners[ev].push(handler); }
+
+function init(){ if(initialized) return; document.addEventListener('click',e=>{ const openBtn=e.target.closest('[data-modal-open]'); if(openBtn){ e.preventDefault(); lastTrigger=openBtn; open(openBtn.getAttribute('data-modal-open'),{trigger:openBtn}); return;} const sheetBtn=e.target.closest('[data-modal-sheet]'); if(sheetBtn){ e.preventDefault(); lastTrigger=sheetBtn; sheet(sheetBtn.getAttribute('data-modal-sheet'),{trigger:sheetBtn}); return;} const closeBtn=e.target.closest('[data-modal-close]'); if(closeBtn){ e.preventDefault(); const ov=closeBtn.closest('.modal-overlay'); close(ov?.dataset.modalId); } }); initialized=true; }
+
+window.__MODAL_DEBUG__ = { openStack: stack, lastTrigger: ()=>lastTrigger };
+
+export const Modal = { init, open, sheet, close, closeAll, setContent, on };
+if (typeof window !== "undefined") window.Modal = Modal;
+export default Modal;

--- a/js/ui-kit.js
+++ b/js/ui-kit.js
@@ -1,3 +1,4 @@
+import { Modal } from './modal-manager.js';
 export const qs = (sel, ctx=document) => ctx.querySelector(sel);
 export const el = (tag, attrs={}, children=[]) => {
   const element = document.createElement(tag);
@@ -24,53 +25,16 @@ export function showToast(type, msg){
 
 export function confirmDialog({title='Confirmar',body='¿Continuar?',confirmText='Aceptar'}){
   return new Promise(res=>{
+    const cancel=el('button',{class:'btn btn-ghost','data-modal-close':''},'Cancelar');
+    const ok=el('button',{class:'btn btn-danger'},confirmText);
     const content=el('div',{class:'stack'},[
       el('p',{},body),
-      el('div',{class:'stack-sm',style:'flex-direction:row;justify-content:flex-end;'},[
-        el('button',{class:'btn btn-ghost',onClick:()=>{closeModal();res(false);}},'Cancelar'),
-        el('button',{class:'btn btn-danger',onClick:()=>{closeModal();res(true);}},confirmText)
-      ])
+      el('div',{class:'stack-sm',style:'flex-direction:row;justify-content:flex-end;'},[cancel,ok])
     ]);
-    openModal(title,content);
+    const id=Modal.open(content,{title});
+    cancel.addEventListener('click',()=>{Modal.close(id);res(false);});
+    ok.addEventListener('click',()=>{Modal.close(id);res(true);});
   });
-}
-
-export function openModal(title,content){
-  const overlay=el('div',{class:'modal-overlay',role:'dialog'},[
-    el('div',{class:'modal'},[
-      el('header',{class:'stack-sm',style:'margin-bottom:8px;'},[
-        el('h2',{},title),
-        el('button',{class:'btn-icon',onClick:closeModal},el('span',{class:'material-symbols-outlined'},'close'))
-      ]),
-      content
-    ])
-  ]);
-  document.body.appendChild(overlay);
-  overlay.addEventListener('click',e=>{if(e.target===overlay) closeModal();});
-  document.addEventListener('keydown', escListener);
-}
-
-export function openSheet(title,content){
-  const overlay=el('div',{class:'modal-overlay'},[
-    el('div',{class:'sheet',role:'dialog'},[
-      el('header',{class:'stack-sm',style:'margin-bottom:8px;'},[
-        el('h2',{},title),
-        el('button',{class:'btn-icon',onClick:closeModal},el('span',{class:'material-symbols-outlined'},'close'))
-      ]),
-      content
-    ])
-  ]);
-  document.body.appendChild(overlay);
-  overlay.addEventListener('click',e=>{if(e.target===overlay) closeModal();});
-  document.addEventListener('keydown', escListener);
-}
-
-function escListener(e){ if(e.key==='Escape') closeModal(); }
-
-export function closeModal(){
-  const overlay = qs('.modal-overlay');
-  if(overlay) overlay.remove();
-  document.removeEventListener('keydown', escListener);
 }
 
 export function renderResponsiveTable(container, config){

--- a/js/utils.js
+++ b/js/utils.js
@@ -15,13 +15,3 @@ export const buildWhere = (filters={}) => {
   Object.entries(filters).forEach(([k,v])=>{ if(v!==undefined && v!=='') arr.push(where(k,'==',v)); });
   return arr;
 };
-
-// Modal helpers
-export function openModal(id){
-  qs(id).classList.add('open');
-  const first = qs(id+' .modal');
-  first?.focus();
-}
-export function closeModal(id){
-  qs(id).classList.remove('open');
-}

--- a/js/views/arbitros.js
+++ b/js/views/arbitros.js
@@ -1,4 +1,5 @@
-import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { Modal } from '../modal-manager.js';
+import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { listArbitros, getArbitro, createArbitro, updateArbitro, deleteArbitro } from '../data/arbitros.js';
 import { listDelegaciones } from '../data/delegaciones.js';
 import { listPagos, createPago, sumPagos } from '../data/pagos-arbitros.js';
@@ -101,10 +102,10 @@ export async function render(){
       const btn=form.querySelector('button'); setBusy(btn,true);
       try{
         if(row) await updateArbitro(row.id,data); else await createArbitro(data);
-        closeModal(); showToast('success','Guardado'); load();
+        Modal.close(); showToast('success','Guardado'); load();
       }catch(err){showToast('error',err.message);}finally{setBusy(btn,false);} 
     });
-    openSheet(row?'Editar árbitro':'Nuevo árbitro',form);
+    Modal.sheet(form,{title:row?'Editar árbitro':'Nuevo árbitro'});
   }
   const openNew=()=>openForm(null);
   async function openEdit(id){ const r=await getArbitro(id); if(r) openForm(r); }
@@ -134,10 +135,10 @@ export async function render(){
           metodo: data.metodo,
           referencia: data.referencia
         });
-        closeModal(); showToast('success','Pago registrado'); load();
+        Modal.close(); showToast('success','Pago registrado'); load();
       }catch(err){showToast('error',err.message);}finally{setBusy(btn,false);} 
     });
-    openSheet(`Registrar pago • ${row.nombre}`,form);
+    Modal.sheet(form,{title:`Registrar pago • ${row.nombre}`});
   }
 
   async function openDetail(id){
@@ -188,9 +189,9 @@ export async function render(){
     const content = el('div',{class:'stack'},[
       el('h3',{},arbitro.nombre||''),
       tabs,
-      role==='admin'?el('button',{class:'btn btn-primary',onClick:()=>{closeModal();openPago({id:arbitro.id,nombre:arbitro.nombre});}},'Registrar pago'):null
+      role==='admin'?el('button',{class:'btn btn-primary',onClick:()=>{Modal.close();openPago({id:arbitro.id,nombre:arbitro.nombre});}},'Registrar pago'):null
     ]);
-    openSheet('Detalle árbitro',content);
+    Modal.sheet(content,{title:'Detalle árbitro'});
   }
 
   await load();

--- a/js/views/cobros.js
+++ b/js/views/cobros.js
@@ -1,5 +1,6 @@
+import { Modal } from '../modal-manager.js';
 import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from '../firebase-ui.js';
-import { el, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { el, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
@@ -49,10 +50,10 @@ export async function render(){
       try{
         if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros/${row.id}`), {equipo:data.equipo,monto:data.monto,saldo:data.saldo}); }
         else{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros`), {equipo:data.equipo,monto:data.monto,saldo:data.saldo}); }
-        closeModal(); load(); showToast('success','Guardado');
+        Modal.close(); load(); showToast('success','Guardado');
       }catch(err){ showToast('error',err.message); } finally{ setBusy(btn,false); }
     });
-    openSheet(row?'Editar cobro':'Nuevo cobro',form);
+    Modal.sheet(form,{title:row?'Editar cobro':'Nuevo cobro'});
   }
 
   const openEdit = id=>{ const row=rows.find(r=>r.id===id); if(row) openForm(row); };
@@ -73,10 +74,10 @@ export async function render(){
       const data=readForm(form); const m=Number(data.monto);
       if(m<=0 || m>row.saldo){showToast('error','Monto inválido');return;}
       const btn=form.querySelector('button'); setBusy(btn,true);
-      try{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros/${row.id}/abonos`), {monto:m,fecha:new Date().toISOString()}); closeModal(); showToast('success','Abono registrado'); }
+      try{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/cobros/${row.id}/abonos`), {monto:m,fecha:new Date().toISOString()}); Modal.close(); showToast('success','Abono registrado'); }
       catch(err){showToast('error',err.message);} finally{ setBusy(btn,false); }
     });
-    openSheet('Registrar abono',form);
+    Modal.sheet(form,{title:'Registrar abono'});
   }
 
   await load();

--- a/js/views/delegaciones.js
+++ b/js/views/delegaciones.js
@@ -1,5 +1,6 @@
+import { Modal } from '../modal-manager.js';
 import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
-import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID } from '../constants.js';
 
@@ -43,12 +44,12 @@ export async function render(){
       try{
         if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/delegaciones/${row.id}`), data); }
         else{ await addDoc(collection(db,`ligas/${LIGA_ID}/delegaciones`), data); }
-        closeModal(); load(); showToast('success','Guardado');
+        Modal.close(); load(); showToast('success','Guardado');
       }
       catch(err){ showToast('error',err.message); }
       finally{ setBusy(btn,false); }
     });
-    openSheet(row?'Editar delegación':'Nueva delegación',form);
+    Modal.sheet(form,{title:row?'Editar delegación':'Nueva delegación'});
   }
 
   const openNew = () => openForm(null);

--- a/js/views/equipos.js
+++ b/js/views/equipos.js
@@ -1,5 +1,6 @@
+import { Modal } from '../modal-manager.js';
 import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
-import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID } from '../constants.js';
 
@@ -44,11 +45,11 @@ export async function render(){
       try{
         if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/equipos/${row.id}`), data); }
         else{ await addDoc(collection(db,`ligas/${LIGA_ID}/equipos`), data); }
-        closeModal(); load(); showToast('success','Guardado');
+        Modal.close(); load(); showToast('success','Guardado');
       }catch(err){ showToast('error',err.message); }
       finally{ setBusy(btn,false); }
     });
-    openSheet(row?'Editar equipo':'Nuevo equipo',form);
+    Modal.sheet(form,{title:row?'Editar equipo':'Nuevo equipo'});
   }
 
   const openNew = () => openForm(null);

--- a/js/views/partidos.js
+++ b/js/views/partidos.js
@@ -1,5 +1,6 @@
+import { Modal } from '../modal-manager.js';
 import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
-import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal } from '../ui-kit.js';
+import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
@@ -43,10 +44,10 @@ export async function render(){
       try{
         if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos/${row.id}`), data); }
         else{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/partidos`), data); }
-        closeModal(); load(); showToast('success','Guardado');
+        Modal.close(); load(); showToast('success','Guardado');
       }catch(err){showToast('error',err.message);} finally{setBusy(btn,false);}
     });
-    openSheet(row?'Editar partido':'Nuevo partido', form);
+    Modal.sheet(form,{title:row?'Editar partido':'Nuevo partido'});
   }
 
   const openNew = ()=>openForm(null);

--- a/js/views/tarifas.js
+++ b/js/views/tarifas.js
@@ -1,5 +1,6 @@
+import { Modal } from '../modal-manager.js';
 import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from '../firebase-ui.js';
-import { el, renderResponsiveTable, openSheet, readForm, setBusy, showToast, emptyState, closeModal, confirmDialog } from '../ui-kit.js';
+import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState, confirmDialog } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
 
@@ -46,11 +47,11 @@ export async function render(){
       try{
         if(row){ await updateDoc(doc(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas/${row.id}`), data); }
         else{ await addDoc(collection(db,`ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas`), data); }
-        closeModal(); load(); showToast('success','Guardado');
+        Modal.close(); load(); showToast('success','Guardado');
       }catch(err){ showToast('error',err.message); }
       finally{ setBusy(btn,false); }
     });
-    openSheet(row?'Editar tarifa':'Nueva tarifa',form);
+    Modal.sheet(form,{title:row?'Editar tarifa':'Nueva tarifa'});
   }
 
   const openNew = ()=>openForm(null);


### PR DESCRIPTION
## Summary
- add `modal-manager.js` with centralized API, focus trapping, scroll locking and stack support
- introduce `modals.css` for modal and sheet styling using design tokens
- update SPA to initialize and close modals on navigation and refactor views to use the new Modal API

## Testing
- `node -e "import('./js/modal-manager.js').then(m=>console.log('loaded'))"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97e6bde8832587641542772e878a