### PR TITLE
feat: improve row actions accessibility and admin checks

### DIFF
--- a/css/actions.css
+++ b/css/actions.css
@@ -11,10 +11,12 @@
 }
 html:not(.is-mobile) .action-btn:hover { background: color-mix(in srgb, var(--surface, #fff) 88%, #000 12%); }
 .action-btn:active { transform: translateY(1px); }
+.action-btn:focus-visible { outline:2px solid var(--ring, #3b82f6); outline-offset:2px; }
 .action-btn--edit { color:#2563eb; border-color: color-mix(in srgb, #2563eb 30%, var(--bd)); }
 .action-btn--delete { color:#ef4444; border-color: color-mix(in srgb, #ef4444 30%, var(--bd)); }
 .action-btn[disabled] { opacity:.5; cursor:not-allowed; }
 .actions--card { justify-content:flex-end; margin-top:8px; }
+html.is-mobile .action-btn { height:44px; width:44px; }
 /* en tablas, agrega una columna Acciones (desktop) */
 @media (pointer: fine) and (min-width:768px){
   html:not(.is-mobile) th.th-actions { width: 120px; text-align:right; }

--- a/js/row-actions.js
+++ b/js/row-actions.js
@@ -2,6 +2,8 @@
 // Uso: after render de una vista, llama a injectRowActions({...})
 import { userRole } from './firebase-ui.js'; // función que devuelve "admin"|"consulta" (ajusta si tu helper tiene otro nombre)
 
+const VERSION = '1.1.0';
+
 /**
  * @typedef {Object} ActionsOptions
  * @property {HTMLElement} root            - contenedor donde buscar filas
@@ -12,72 +14,88 @@ import { userRole } from './firebase-ui.js'; // función que devuelve "admin"|"c
  * @property {boolean} [onlyAdmin=true]        - si true, solo muestra a admins
  */
 export function injectRowActions(opts){
-  const role = (typeof userRole === 'function' ? userRole() : 'consulta');
   const onlyAdmin = opts.onlyAdmin !== false;
-  if (onlyAdmin && role !== 'admin') return; // no muestra nada a consulta
-
   const root = opts.root || document;
-  const rows = root.querySelectorAll(opts.rowSelector);
-  if (!rows.length) return;
+  const getRole = opts.getRole || userRole;
 
-  rows.forEach(el=>{
-    const id = el.getAttribute('data-id');
-    if (!id || el.querySelector('[data-actions]')) return; // ya tiene acciones
-    const isTableRow = el.tagName === 'TR' || el.closest('table');
-    const mode = opts.mode || (isTableRow ? 'table' : 'card');
+  Promise.resolve(typeof getRole === 'function' ? getRole() : 'consulta').then(role=>{
+    if (onlyAdmin && role !== 'admin') return; // no muestra nada a consulta
 
-    if (mode === 'table') {
-      // Cabecera: asegura th "Acciones"
-      const table = el.closest('table');
-      if (table && !table.querySelector('thead th.th-actions')) {
-        const th = document.createElement('th');
-        th.className = 'th-actions'; th.textContent = 'Acciones';
-        const theadRow = table.tHead?.rows[0];
-        if (theadRow) theadRow.appendChild(th);
-      }
-      // Celda de acciones
-      const td = document.createElement('td');
-      td.className = 'cell-actions'; td.setAttribute('data-actions','');
-      td.appendChild(makeBtn('edit', 'Editar'));
-      td.appendChild(makeBtn('delete', 'Eliminar'));
-      el.appendChild(td);
-    } else {
-      // Card / lista apilada
-      const footer = document.createElement('div');
-      footer.className = 'actions actions--card'; footer.setAttribute('data-actions','');
-      footer.appendChild(makeBtn('edit', 'Editar'));
-      footer.appendChild(makeBtn('delete', 'Eliminar'));
-      el.appendChild(footer);
+    const rows = root.querySelectorAll(opts.rowSelector);
+    if (!rows.length) {
+      window.__ROW_ACTIONS_DEBUG__ = { version: VERSION, rows: 0, injected: 0, mode: 'n/a', role };
+      return;
     }
+    let injected = 0;
+
+    rows.forEach(el=>{
+      const id = el.getAttribute('data-id');
+      if (!id || el.querySelector('[data-actions]')) return; // ya tiene acciones
+      const isTableRow = el.tagName === 'TR' || el.closest('table');
+      const mode = opts.mode || (isTableRow ? 'table' : 'card');
+
+      if (mode === 'table') {
+        // Cabecera: asegura th "Acciones"
+        const table = el.closest('table');
+        if (table && !table.querySelector('thead th.th-actions')) {
+          const th = document.createElement('th');
+          th.className = 'th-actions'; th.textContent = 'Acciones';
+          const theadRow = table.tHead?.rows[0];
+          if (theadRow) theadRow.appendChild(th);
+        }
+        // Celda de acciones
+        const td = document.createElement('td');
+        td.className = 'cell-actions'; td.setAttribute('data-actions','');
+        td.appendChild(makeBtn('edit', 'Editar'));
+        td.appendChild(makeBtn('delete', 'Eliminar'));
+        el.appendChild(td);
+      } else {
+        // Card / lista apilada
+        const footer = document.createElement('div');
+        footer.className = 'actions actions--card'; footer.setAttribute('data-actions','');
+        footer.appendChild(makeBtn('edit', 'Editar'));
+        footer.appendChild(makeBtn('delete', 'Eliminar'));
+        el.appendChild(footer);
+      }
+      injected++;
+    });
+
+    window.__ROW_ACTIONS_DEBUG__ = {
+      version: VERSION,
+      rows: rows.length,
+      injected,
+      mode: opts.mode || (rows[0].tagName === 'TR' || rows[0].closest('table') ? 'table' : 'card'),
+      role
+    };
+
+    if (!root.__rowActionsListener) {
+      root.__rowActionsListener = async ev => {
+        const btn = ev.target.closest('[data-action]');
+        if (!btn) return;
+        const host = btn.closest('[data-id]');
+        if (!host) return;
+        const id = host.getAttribute('data-id');
+        if (!id) return;
+        const type = btn.getAttribute('data-action');
+        if (type === 'edit') {
+          root.__rowActionsHandler?.onEdit?.({ id, el: host });
+        } else if (type === 'delete') {
+          if (!(await confirmDelete(host.getAttribute('data-name') || 'registro'))) return;
+          btn.setAttribute('disabled', 'true');
+          try {
+            await root.__rowActionsHandler?.onDelete?.({ id, el: host });
+            const isRow = host.tagName === 'TR';
+            if (isRow) host.remove();
+            else host.classList.add('hidden');
+          } finally {
+            btn.removeAttribute('disabled');
+          }
+        }
+      };
+      root.addEventListener('click', root.__rowActionsListener);
+    }
+    root.__rowActionsHandler = { onEdit: opts.onEdit, onDelete: opts.onDelete };
   });
-
-  // Delegación de eventos (un solo listener)
-  root.addEventListener('click', async (ev)=>{
-    const btn = ev.target.closest('[data-action]');
-    if (!btn) return;
-    const host = btn.closest('[data-id]');
-    if (!host) return;
-    const id = host.getAttribute('data-id');
-    if (!id) return;
-
-    const type = btn.getAttribute('data-action');
-    if (type === 'edit') {
-      opts.onEdit?.({ id, el: host });
-    } else if (type === 'delete') {
-      // Confirmación simple + bloqueo mientras elimina
-      if (!(await confirmDelete(host.getAttribute('data-name') || 'registro'))) return;
-      btn.setAttribute('disabled', 'true');
-      try {
-        await opts.onDelete?.({ id, el: host });
-        // Si el handler no removió la fila, lo hacemos aquí
-        const isRow = host.tagName === 'TR';
-        if (isRow) host.remove();
-        else host.classList.add('hidden');
-      } finally {
-        btn.removeAttribute('disabled');
-      }
-    }
-  }, { once: false });
 
   function makeBtn(kind, label){
     const b = document.createElement('button');


### PR DESCRIPTION
## Summary
- ensure row action buttons resolve user role before injecting and avoid duplicate listeners
- add debug info and idempotent handlers for delegated edit/delete actions
- improve action button accessibility with focus rings and larger mobile targets

## Testing
- `node --check js/row-actions.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab9f8c6b1883259ff6b334410fbdc7