### PR TITLE
feat: add reusable combobox component

### DIFF
--- a/css/select.css
+++ b/css/select.css
@@ -1,0 +1,8 @@
+.combobox{position:relative;}
+.combobox .cb-list{position:absolute;z-index:1000;background:var(--surface);border:1px solid #ccc;width:100%;max-height:200px;overflow:auto;margin-top:4px;padding:0;list-style:none;box-shadow:0 2px 4px rgba(0,0,0,0.2);}
+.combobox .cb-list li{padding:8px;cursor:pointer;}
+.combobox .cb-list li:hover{background:var(--surface-hover,#eee);}
+.combobox .cb-list li[hidden]{display:none;}
+.combobox .cb-loading,
+.combobox .cb-empty,
+.combobox .cb-error{padding:8px;color:#666;}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="./css/nav.css">
   <link rel="stylesheet" href="./css/arbitros.css">
   <link rel="stylesheet" href="./css/modals.css">
+  <link rel="stylesheet" href="./css/select.css">
 </head>
 <body>
   <header class="topbar" role="banner">

--- a/js/combobox.js
+++ b/js/combobox.js
@@ -1,0 +1,106 @@
+import { el } from './ui-kit.js';
+
+const catalogCache = {};
+
+function cacheFetch(key, fetcher){
+  if(catalogCache[key]) return catalogCache[key];
+  catalogCache[key] = fetcher().catch(err=>{ delete catalogCache[key]; throw err; });
+  return catalogCache[key];
+}
+
+function createBaseSelect({name, placeholder='--', selectedId, fetch}){
+  const hidden = el('input',{type:'hidden',name,value:selectedId||''});
+  const input = el('input',{
+    class:'input',
+    placeholder,
+    'aria-haspopup':'listbox',
+    autocomplete:'off'
+  });
+  const list = el('ul',{class:'cb-list',role:'listbox',hidden:true});
+  const wrapper = el('div',{class:'combobox',role:'combobox','aria-expanded':'false'},[hidden,input,list]);
+
+  let items = [];
+  let loaded = false;
+
+  async function ensure(){
+    if(loaded) return;
+    loaded = true;
+    list.innerHTML = '<li class="cb-loading">Cargando...</li>';
+    try{
+      items = await fetch();
+      list.innerHTML='';
+      items.forEach(it=>{
+        const li = el('li',{role:'option','data-id':it.id},it.label);
+        if(it.id===selectedId){
+          input.value = it.label;
+          hidden.value = it.id;
+        }
+        list.appendChild(li);
+      });
+      if(!items.length){
+        list.innerHTML = '<li class="cb-empty">Sin resultados</li>';
+      }
+    }catch(err){
+      list.innerHTML = '<li class="cb-error">Error al cargar</li>';
+      console.error(err);
+    }
+  }
+
+  input.addEventListener('focus', async ()=>{
+    wrapper.setAttribute('aria-expanded','true');
+    list.hidden = false;
+    await ensure();
+  });
+
+  input.addEventListener('input',()=>{
+    const q = input.value.toLowerCase();
+    Array.from(list.children).forEach(li=>{
+      if(!li.dataset.id) return;
+      li.hidden = !li.textContent.toLowerCase().includes(q);
+    });
+  });
+
+  list.addEventListener('click',e=>{
+    const li = e.target.closest('li[data-id]');
+    if(!li) return;
+    hidden.value = li.dataset.id;
+    input.value = li.textContent;
+    list.hidden = true;
+    wrapper.setAttribute('aria-expanded','false');
+    wrapper.dispatchEvent(new Event('change'));
+  });
+
+  document.addEventListener('click',e=>{
+    if(!wrapper.contains(e.target)){
+      list.hidden = true;
+      wrapper.setAttribute('aria-expanded','false');
+    }
+  });
+
+  return wrapper;
+}
+
+export function createFirestoreSelect({name, placeholder='--', collectionPath, labelField='nombre', selectedId, cacheKey}){
+  return createBaseSelect({
+    name,
+    placeholder,
+    selectedId,
+    fetch: ()=>cacheFetch(cacheKey||collectionPath, async ()=>{
+      const { db, collection, getDocs } = await import('./firebase-ui.js');
+      const snap = await getDocs(collection(db, collectionPath));
+      const arr = snap.docs.map(d=>({id:d.id,label:d.data()[labelField]||d.id}));
+      arr.sort((a,b)=>a.label.localeCompare(b.label));
+      return arr;
+    })
+  });
+}
+
+export function createStaticSelect({name, placeholder='--', options=[], selectedId}){
+  return createBaseSelect({
+    name,
+    placeholder,
+    selectedId,
+    fetch: async ()=>options
+  });
+}
+

--- a/js/views/equipos.js
+++ b/js/views/equipos.js
@@ -3,6 +3,7 @@ import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } fr
 import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID } from '../constants.js';
+import { createFirestoreSelect, createStaticSelect } from '../combobox.js';
 
 export async function render(){
   const section = el('section',{class:'stack'});
@@ -15,14 +16,26 @@ export async function render(){
   section.appendChild(container);
 
   async function load(){
-    const snap = await getDocs(collection(db,`ligas/${LIGA_ID}/equipos`));
-    const rows = snap.docs.map(d=>({id:d.id,...d.data()}));
+    const [equipSnap, delegSnap] = await Promise.all([
+      getDocs(collection(db,`ligas/${LIGA_ID}/equipos`)),
+      getDocs(collection(db,`ligas/${LIGA_ID}/delegaciones`))
+    ]);
+    const delegMap = Object.fromEntries(delegSnap.docs.map(d=>[d.id,d.data().nombre]));
+    const rows = equipSnap.docs.map(d=>({id:d.id,...d.data()}));
     if(!rows.length){
       container.innerHTML='';
       container.appendChild(emptyState({icon:'groups',title:'Sin equipos',body:'',action:{label:'Crear',onClick:openNew}}));
       return;
     }
-    renderResponsiveTable(container,{columns:[{key:'nombre',label:'Nombre'},{key:'delegacion',label:'Delegación'}],rows});
+    renderResponsiveTable(container,{
+      columns:[
+        {key:'nombre',label:'Nombre'},
+        {key:'delegacionId',label:'Delegación',format:v=>delegMap[v]||''},
+        {key:'rama',label:'Rama'},
+        {key:'categoria',label:'Categoría'}
+      ],
+      rows
+    });
     injectRowActions({
       root: container,
       rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
@@ -32,9 +45,35 @@ export async function render(){
   }
 
   function openForm(row){
+    const delegacionSel = createFirestoreSelect({
+      name:'delegacionId',
+      placeholder:'Delegación',
+      collectionPath:`ligas/${LIGA_ID}/delegaciones`,
+      cacheKey:'delegaciones',
+      selectedId:row?.delegacionId
+    });
+    const ramaSel = createStaticSelect({
+      name:'rama',
+      placeholder:'Rama',
+      options:[
+        {id:'Varonil',label:'Varonil'},
+        {id:'Femenil',label:'Femenil'}
+      ],
+      selectedId:row?.rama
+    });
+    const catOptions = [];
+    for(let y=2009;y<=2020;y++) catOptions.push({id:String(y),label:String(y)});
+    const catSel = createStaticSelect({
+      name:'categoria',
+      placeholder:'Categoría',
+      options:catOptions,
+      selectedId:row?.categoria
+    });
     const form = el('form',{class:'stack'},[
       el('label',{},['Nombre', el('input',{class:'input',name:'nombre',required:true,value:row?.nombre||''})]),
-      el('label',{},['Delegación', el('input',{class:'input',name:'delegacion',required:true,value:row?.delegacion||''})]),
+      el('label',{},['Delegación', delegacionSel]),
+      el('label',{},['Rama', ramaSel]),
+      el('label',{},['Categoría', catSel]),
       el('button',{class:'btn btn-primary',type:'submit'},'Guardar')
     ]);
     form.addEventListener('submit', async e=>{


### PR DESCRIPTION
## Summary
- add standalone combobox component with cached Firestore loading and filtering
- integrate component into Equipos form for delegación, rama and categoría
- include basic styles for combobox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba477443083258a12b3a92971becd