### PR TITLE
feat: add admin new button helper across views

### DIFF
--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -54,6 +54,9 @@ p, label, th, td, input, select, button, small { color: var(--text); }
   border-radius: var(--radius); box-shadow: var(--shadow); padding: 16px;
 }
 .section-header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin: 10px 0 14px; }
+.section-header .btn-row{display:flex; gap:8px;}
+.fab{position:fixed;right:16px;bottom:calc(80px + env(safe-area-inset-bottom));width:56px;height:56px;border-radius:50%;border:none;background:var(--primary);color:#fff;box-shadow:var(--shadow);display:flex;align-items:center;justify-content:center;z-index:40;}
+html:not(.is-mobile) .fab{display:none;}
 
 /* Topbar */
 .topbar { position: sticky; top:0; z-index:50; backdrop-filter: saturate(140%) blur(8px); border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 80%, transparent); }

--- a/js/ui-new-button.js
+++ b/js/ui-new-button.js
@@ -1,0 +1,65 @@
+import { el } from './ui-kit.js';
+import { userRole } from './firebase-ui.js';
+
+export async function ensureNewButton(viewRoot, {text, icon='add', onClick, role='admin', fab=false}={}){
+  if(!viewRoot) return;
+  const currentRole = await userRole();
+  // Ensure section header
+  let header = viewRoot.querySelector('.section-header');
+  let heading = viewRoot.querySelector('h1, h2');
+  if(!header){
+    if(!heading){ return; }
+    // convert heading to h1 if needed
+    if(heading.tagName.toLowerCase()!=='h1'){
+      const h1=document.createElement('h1');
+      h1.textContent=heading.textContent;
+      heading.replaceWith(h1); heading=h1;
+    }
+    header=document.createElement('div');
+    header.className='section-header';
+    heading.parentNode.insertBefore(header, heading);
+    header.appendChild(heading);
+  }
+  let row=header.querySelector('.btn-row');
+  if(!row){
+    row=document.createElement('div');
+    row.className='btn-row';
+    header.appendChild(row);
+  }
+  // role check
+  if(currentRole!==role){
+    const existing=row.querySelector('button[data-new]');
+    if(existing) existing.remove();
+    const fabBtn=viewRoot.querySelector('.fab[data-new]');
+    if(fabBtn) fabBtn.remove();
+    return;
+  }
+  let btn=row.querySelector('button[data-new]');
+  if(!btn){
+    btn=el('button',{class:'btn btn-primary','data-new':'','aria-label':text,title:text},[
+      el('span',{class:'material-symbols-outlined'},icon),
+      el('span',{},text)
+    ]);
+    row.appendChild(btn);
+  }
+  if(!btn._listener){
+    btn.addEventListener('click',onClick);
+    btn._listener=true;
+  }
+  // FAB for mobile/iPad
+  if(fab && document.documentElement.classList.contains('is-mobile')){
+    let fabBtn=viewRoot.querySelector('.fab[data-new]');
+    if(!fabBtn){
+      fabBtn=el('button',{class:'fab','data-new':'','aria-label':text,title:text},
+        el('span',{class:'material-symbols-outlined'},icon)
+      );
+      viewRoot.appendChild(fabBtn);
+    }
+    if(!fabBtn._listener){
+      fabBtn.addEventListener('click',onClick);
+      fabBtn._listener=true;
+    }
+  }
+}
+
+export default ensureNewButton;

--- a/js/views/arbitros.js
+++ b/js/views/arbitros.js
@@ -7,34 +7,34 @@ import { listPartidosDeArbitro } from '../data/partidos-arbitro.js';
 import { injectRowActions } from '../row-actions.js';
 import { userRole } from '../firebase-ui.js';
 import { money, formatDate } from '../utils.js';
+import { ensureNewButton } from '../ui-new-button.js';
 
 export async function render(){
   const role = await userRole();
   const section = el('section',{class:'stack'});
-  const header = el('div',{class:'stack-sm',style:'flex-direction:row;flex-wrap:wrap;align-items:center;gap:8px;'},[
-    el('h2',{style:'flex:1 1 100%;'},'Árbitros'),
+  section.appendChild(el('h1',{},'Árbitros'));
+  const toolbar = el('div',{class:'stack-sm',style:'flex-direction:row;flex-wrap:wrap;align-items:center;gap:8px;'},[
     el('input',{type:'search',class:'input',id:'search',placeholder:'Buscar'}),
     el('select',{class:'input',id:'fDeleg'},[el('option',{value:''},'Delegación')]),
     el('select',{class:'input',id:'fActivo'},[
       el('option',{value:''},'Estatus'),
       el('option',{value:'true'},'Activo'),
       el('option',{value:'false'},'Inactivo')
-    ]),
-    role==='admin'?el('button',{class:'btn btn-primary',id:'newBtn'},'Nuevo árbitro'):null
+    ])
   ]);
-  section.appendChild(header);
+  section.appendChild(toolbar);
   const container = el('div');
   section.appendChild(container);
 
   const delegaciones = await listDelegaciones();
-  const sel = header.querySelector('#fDeleg');
+  const sel = toolbar.querySelector('#fDeleg');
   delegaciones.forEach(d=>sel.appendChild(el('option',{value:d.id},d.nombre)));
 
   async function load(){
     const filters={};
-    const q = header.querySelector('#search').value.trim().toLowerCase();
-    const del = header.querySelector('#fDeleg').value;
-    const act = header.querySelector('#fActivo').value;
+    const q = toolbar.querySelector('#search').value.trim().toLowerCase();
+    const del = toolbar.querySelector('#fDeleg').value;
+    const act = toolbar.querySelector('#fActivo').value;
     if(del) filters.delegacionId = del;
     if(act!=='' ) filters.activo = act==='true';
     let rows = await listArbitros(filters);
@@ -48,7 +48,8 @@ export async function render(){
     }
     if(!rows.length){
       container.innerHTML='';
-      container.appendChild(emptyState({icon:'person',title:'Sin árbitros',body:'',action: role==='admin'?{label:'Crear',onClick:openNew}:null}));
+      container.appendChild(emptyState({icon:'person',title:'Sin árbitros',body:'',action: role==='admin'?{label:'Nuevo árbitro',onClick:openNew}:null}));
+      await ensureNewButton(section,{text:'Nuevo árbitro',icon:'add',onClick:openNew,fab:true});
       return;
     }
     renderResponsiveTable(container,{
@@ -74,12 +75,12 @@ export async function render(){
         onDelete: ({id})=>remove(id)
       });
     }
+    await ensureNewButton(section,{text:'Nuevo árbitro',icon:'add',onClick:openNew,fab:true});
   }
 
-  header.querySelector('#search').addEventListener('input',()=>{clearTimeout(header._t);header._t=setTimeout(load,300);});
-  header.querySelector('#fDeleg').addEventListener('change',load);
-  header.querySelector('#fActivo').addEventListener('change',load);
-  if(role==='admin') header.querySelector('#newBtn').addEventListener('click',openNew);
+  toolbar.querySelector('#search').addEventListener('input',()=>{clearTimeout(toolbar._t);toolbar._t=setTimeout(load,300);});
+  toolbar.querySelector('#fDeleg').addEventListener('change',load);
+  toolbar.querySelector('#fActivo').addEventListener('change',load);
 
   container.addEventListener('click',e=>{
     const row = e.target.closest('[data-id]');

--- a/js/views/cobros.js
+++ b/js/views/cobros.js
@@ -1,12 +1,14 @@
 import { Modal } from '../modal-manager.js';
-import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, updateDoc, deleteDoc, userRole } from '../firebase-ui.js';
 import { el, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
+import { ensureNewButton } from '../ui-new-button.js';
 
 export async function render(){
+  const role = await userRole();
   const section=el('section',{class:'stack'});
-  section.appendChild(el('h2',{},'Cobros'));
+  section.appendChild(el('h1',{},'Cobros'));
   const container=el('div',{class:'stack'}); section.appendChild(container);
   let rows=[];
 
@@ -15,7 +17,8 @@ export async function render(){
     rows=snap.docs.map(d=>({id:d.id,...d.data()}));
     if(!rows.length){
       container.innerHTML='';
-      container.appendChild(emptyState({icon:'payments',title:'Sin cobros',body:'',action:null}));
+      container.appendChild(emptyState({icon:'payments',title:'Sin cobros',body:'',action: role==='admin'?{label:'Nuevo cobro',onClick:openNew}:null}));
+      await ensureNewButton(section,{text:'Nuevo cobro',icon:'add',onClick:openNew,fab:true});
       return;
     }
     container.innerHTML='';
@@ -33,6 +36,7 @@ export async function render(){
       onEdit: ({id})=>openEdit(id),
       onDelete: ({id})=>remove(id)
     });
+    await ensureNewButton(section,{text:'Nuevo cobro',icon:'add',onClick:openNew,fab:true});
   }
 
   function openForm(row){
@@ -56,6 +60,7 @@ export async function render(){
     Modal.sheet(form,{title:row?'Editar cobro':'Nuevo cobro'});
   }
 
+  const openNew = ()=>openForm(null);
   const openEdit = id=>{ const row=rows.find(r=>r.id===id); if(row) openForm(row); };
 
   async function remove(id){

--- a/js/views/partidos.js
+++ b/js/views/partidos.js
@@ -1,16 +1,14 @@
 import { Modal } from '../modal-manager.js';
-import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc } from '../firebase-ui.js';
+import { db, collection, getDocs, addDoc, doc, getDoc, updateDoc, deleteDoc, userRole } from '../firebase-ui.js';
 import { el, renderResponsiveTable, readForm, setBusy, showToast, emptyState } from '../ui-kit.js';
 import { injectRowActions } from '../row-actions.js';
 import { LIGA_ID, TEMP_ID } from '../constants.js';
+import { ensureNewButton } from '../ui-new-button.js';
 
 export async function render(){
+  const role = await userRole();
   const section=el('section',{class:'stack'});
-  const header=el('div',{class:'stack-sm',style:'flex-direction:row;align-items:center;'},[
-    el('h2',{style:'flex:1;'},'Partidos'),
-    el('button',{class:'btn',id:'newBtn'},'Nuevo')
-  ]);
-  section.appendChild(header);
+  section.appendChild(el('h1',{},'Partidos'));
   const container=el('div'); section.appendChild(container);
 
   async function load(){
@@ -18,7 +16,8 @@ export async function render(){
     const rows=snap.docs.map(d=>({id:d.id,...d.data()}));
     if(!rows.length){
       container.innerHTML='';
-      container.appendChild(emptyState({icon:'sports',title:'Sin partidos',body:'',action:{label:'Crear',onClick:openNew}}));
+      container.appendChild(emptyState({icon:'sports',title:'Sin partidos',body:'',action: role==='admin'?{label:'Nuevo partido',onClick:openNew}:null}));
+      await ensureNewButton(section,{text:'Nuevo partido',icon:'add',onClick:openNew,fab:true});
       return;
     }
     renderResponsiveTable(container,{columns:[{key:'fecha',label:'Fecha'},{key:'local',label:'Local'},{key:'visitante',label:'Visitante'}],rows});
@@ -28,6 +27,7 @@ export async function render(){
       onEdit: ({id})=>openEdit(id),
       onDelete: ({id})=>remove(id)
     });
+    await ensureNewButton(section,{text:'Nuevo partido',icon:'add',onClick:openNew,fab:true});
   }
 
   function openForm(row){
@@ -62,7 +62,6 @@ export async function render(){
     catch(err){ showToast('error',err.message); }
   }
 
-  header.querySelector('#newBtn').addEventListener('click',openNew);
   await load();
   return section;
 }


### PR DESCRIPTION
## Summary
- add `ensureNewButton` helper to reliably inject "Nuevo" buttons and optional FABs
- wire up helper in partidos, cobros and árbitros views with empty-state actions
- style header button row and floating action button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba6dedf188325bb7802112bdc583f