### PR TITLE
Fix desktop layout with static sidebar

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1,0 +1,77 @@
+:root {
+  --topbar-h: 56px;
+  --sidebar-w: 264px;
+}
+
+/* Mobile first layout */
+.app-layout {
+  min-height: calc(100dvh - var(--topbar-h));
+}
+
+.topbar {
+  height: var(--topbar-h);
+  z-index: 50;
+}
+
+.sidebar {
+  display: none;
+}
+
+.app-main {
+  min-height: calc(100dvh - var(--topbar-h));
+  overflow: auto;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s ease;
+  z-index: 60; /* overlay above topbar */
+}
+.drawer-overlay .drawer {
+  background: var(--surface);
+  width: var(--sidebar-w);
+  height: 100%;
+  transform: translateX(-100%);
+  transition: transform .3s ease;
+  z-index: 70; /* drawer above overlay */
+}
+.drawer-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+.drawer-overlay.open .drawer {
+  transform: translateX(0);
+}
+
+@media (pointer: fine) and (min-width:1024px) {
+  .app-layout {
+    display: grid;
+    grid-template-columns: var(--sidebar-w) minmax(0,1fr);
+    grid-template-rows: var(--topbar-h) 1fr;
+    min-height: 100dvh;
+  }
+  .topbar {
+    grid-column: 1 / 3;
+    grid-row: 1;
+    position: sticky;
+    top: 0;
+  }
+  .sidebar {
+    display: block;
+    grid-column: 1;
+    grid-row: 2;
+    height: 100%;
+  }
+  .app-main {
+    grid-column: 2;
+    grid-row: 2;
+  }
+  .drawer-overlay {
+    display: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -15,35 +15,53 @@
   <link rel="stylesheet" href="./css/arbitros.css">
   <link rel="stylesheet" href="./css/modals.css">
   <link rel="stylesheet" href="./css/select.css">
+  <link rel="stylesheet" href="./css/layout.css">
 </head>
 <body>
-  <header class="topbar" role="banner">
-    <div class="inner">
-      <button id="menu-btn" class="btn-icon menu-button" aria-label="Menú" aria-controls="drawer" aria-expanded="false">
-        <span class="material-symbols-outlined">menu</span>
-      </button>
-      <h1 class="topbar-title">Berumen Sports • Liga 2025</h1>
-      <div class="topbar-user">
-        <span id="user-role" class="badge"></span>
-        <span id="user-email" class="truncate"></span>
-        <button id="logout-btn" class="btn-icon" aria-label="Salir"><span class="material-symbols-outlined">logout</span></button>
+  <div class="app-layout" id="app-layout">
+    <header class="topbar" id="topbar" role="banner">
+      <div class="inner">
+        <button id="menu-btn" class="btn-icon menu-button" aria-label="Menú" aria-controls="drawer" aria-expanded="false">
+          <span class="material-symbols-outlined">menu</span>
+        </button>
+        <h1 class="topbar-title">Berumen Sports • Liga 2025</h1>
+        <div class="topbar-user">
+          <span id="user-role" class="badge"></span>
+          <span id="user-email" class="truncate"></span>
+          <button id="logout-btn" class="btn-icon" aria-label="Salir"><span class="material-symbols-outlined">logout</span></button>
+        </div>
       </div>
+    </header>
+    <aside class="sidebar" id="sidebar-static">
+      <nav>
+        <a href="#/">Inicio</a>
+        <a href="#/partidos">Partidos</a>
+        <a href="#/equipos">Equipos</a>
+        <a href="#/cobros">Cobros</a>
+        <a href="#/arbitros">Árbitros</a>
+        <a href="#/delegaciones">Delegaciones</a>
+        <a href="#/tarifas">Tarifas</a>
+        <a href="#/reportes">Reportes</a>
+        <a href="#/mas">Más</a>
+      </nav>
+    </aside>
+    <main class="app-main" id="app"></main>
+  </div>
+  <div class="drawer-overlay" id="drawer" hidden>
+    <div class="drawer">
+      <nav>
+        <a href="#/">Inicio</a>
+        <a href="#/partidos">Partidos</a>
+        <a href="#/equipos">Equipos</a>
+        <a href="#/cobros">Cobros</a>
+        <a href="#/arbitros">Árbitros</a>
+        <a href="#/delegaciones">Delegaciones</a>
+        <a href="#/tarifas">Tarifas</a>
+        <a href="#/reportes">Reportes</a>
+        <a href="#/mas">Más</a>
+      </nav>
     </div>
-  </header>
-  <aside id="drawer" class="sidedrawer" role="navigation" aria-label="Menú principal" hidden>
-    <nav>
-      <a href="#/">Inicio</a>
-      <a href="#/partidos">Partidos</a>
-      <a href="#/equipos">Equipos</a>
-      <a href="#/cobros">Cobros</a>
-      <a href="#/arbitros">Árbitros</a>
-      <a href="#/delegaciones">Delegaciones</a>
-      <a href="#/tarifas">Tarifas</a>
-      <a href="#/reportes">Reportes</a>
-      <a href="#/mas">Más</a>
-    </nav>
-  </aside>
-  <main id="app" class="container"></main>
+  </div>
   <nav class="tabbar" role="tablist">
     <a href="#/" class="tab" role="tab" aria-label="Inicio" aria-selected="false"><span class="material-symbols-outlined">home</span><span class="tab-label">Inicio</span></a>
     <a href="#/partidos" class="tab" role="tab" aria-label="Partidos" aria-selected="false"><span class="material-symbols-outlined">sports</span><span class="tab-label">Partidos</span></a>

--- a/js/nav.js
+++ b/js/nav.js
@@ -18,10 +18,11 @@ let state = {
   getAuthState: null,
   getRole: null,
   onSignOut: null,
-  drawer: null,
+  drawer: null,        // overlay container
+  drawerPanel: null,   // drawer content
+  sidebar: null,       // static sidebar
   menuBtn: null,
   tabbar: null,
-  overlay: null,
   lastFocus: null
 };
 
@@ -42,17 +43,17 @@ export function initNav({ getAuthState, getRole, navigate, onSignOut }) {
   state.navigate = navigate;
   state.onSignOut = onSignOut;
 
-  state.drawer = document.querySelector('.sidedrawer');
+  state.drawer = document.getElementById('drawer');
+  state.drawerPanel = state.drawer?.querySelector('.drawer');
+  state.sidebar = document.getElementById('sidebar-static');
   state.menuBtn = document.getElementById('menu-btn');
   state.tabbar = document.querySelector('.tabbar');
 
-  if (state.drawer) {
-    state.drawer.addEventListener('click', handleNavClick);
-    state.drawer.addEventListener('keydown', handleDrawerKeydown);
-  }
-  if (state.tabbar) {
-    state.tabbar.addEventListener('click', handleNavClick);
-  }
+  state.drawerPanel?.addEventListener('click', handleNavClick);
+  state.drawerPanel?.addEventListener('keydown', handleDrawerKeydown);
+  state.drawer?.addEventListener('click', (e) => { if (e.target === state.drawer) closeDrawer(); });
+  state.sidebar?.addEventListener('click', handleNavClick);
+  state.tabbar?.addEventListener('click', handleNavClick);
   state.menuBtn?.addEventListener('click', (e) => { e.preventDefault(); toggleDrawer(); });
 
   const logoutBtn = document.getElementById('logout-btn');
@@ -61,11 +62,6 @@ export function initNav({ getAuthState, getRole, navigate, onSignOut }) {
     closeDrawer();
     await state.onSignOut?.();
   });
-
-  state.overlay = document.createElement('div');
-  state.overlay.className = 'drawer-overlay';
-  state.overlay.addEventListener('click', closeDrawer);
-  document.body.appendChild(state.overlay);
 
   window.addEventListener('hashchange', () => {
     if (state.locked) return;
@@ -127,8 +123,16 @@ export function setActiveRoute(route) {
       else t.removeAttribute('aria-current');
     });
   }
-  if (state.drawer) {
-    const links = Array.from(state.drawer.querySelectorAll('a'));
+  if (state.drawerPanel) {
+    const links = Array.from(state.drawerPanel.querySelectorAll('a'));
+    links.forEach(a => {
+      const active = canonicalize(a.getAttribute('href')) === target;
+      if (active) a.setAttribute('aria-current', 'page');
+      else a.removeAttribute('aria-current');
+    });
+  }
+  if (state.sidebar) {
+    const links = Array.from(state.sidebar.querySelectorAll('a'));
     links.forEach(a => {
       const active = canonicalize(a.getAttribute('href')) === target;
       if (active) a.setAttribute('aria-current', 'page');
@@ -143,7 +147,6 @@ export function openDrawer() {
   state.lastFocus = document.activeElement;
   state.drawer.hidden = false;
   state.drawer.classList.add('open');
-  state.overlay.classList.add('active');
   document.body.classList.add('lock-scroll');
   state.menuBtn?.setAttribute('aria-expanded', 'true');
   const focusable = state.drawer.querySelector('a,button,[tabindex]:not([tabindex="-1"])');
@@ -153,7 +156,6 @@ export function openDrawer() {
 export function closeDrawer() {
   if (!state.drawer) return;
   state.drawer.classList.remove('open');
-  state.overlay.classList.remove('active');
   document.body.classList.remove('lock-scroll');
   state.menuBtn?.setAttribute('aria-expanded', 'false');
   state.drawer.addEventListener('transitionend', () => {


### PR DESCRIPTION
## Summary
- Add responsive grid layout with static desktop sidebar and overlay drawer on mobile
- Restructure HTML layout around topbar, sidebar, and main content
- Update navigation script to handle new sidebar/drawer structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcaa479808325aee9c93cb1d22fcd