### PR TITLE
fix: handle primitive children in ui helper

### DIFF
--- a/js/ui-kit.js
+++ b/js/ui-kit.js
@@ -7,10 +7,14 @@ export const el = (tag, attrs={}, children=[]) => {
     else if(k==='class') element.className = v;
     else if(v!==false && v!=null) element.setAttribute(k,v);
   });
-  (Array.isArray(children)?children:[children]).forEach(c => {
-    if(c==null) return;
-    if(typeof c === 'string' || typeof c === 'number') element.appendChild(document.createTextNode(c));
-    else element.appendChild(c);
+  (Array.isArray(children) ? children : [children]).forEach(c => {
+    if (c == null) return;
+    // Allow primitive values like booleans to be rendered as text nodes
+    if (c instanceof Node) {
+      element.appendChild(c);
+    } else {
+      element.appendChild(document.createTextNode(String(c)));
+    }
   });
   return element;
 };


### PR DESCRIPTION
## Summary
- make ui helper `el` convert primitive children values into text nodes
- prevent appendChild errors when booleans or other non-node values are provided

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abd5629f0c83259184d38f7ce1dc26