### PR TITLE
Fix Firestore rules for arbitros collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,10 +23,14 @@ service cloud.firestore {
         allow write: if isAdmin() && request.resource.data.ligaId == 'BERUMEN' && request.resource.data.categoria >= 2009 && request.resource.data.categoria <= 2020;
       }
       match /arbitros/{arbitroId} {
-        allow read: if isSignedIn() && ligaId == 'BERUMEN';
-        allow create, update, delete: if isSignedIn() && ligaId == 'BERUMEN' && get(/databases/$(database)/documents/ligas/$(ligaId)/usuarios/$(request.auth.uid)).data.role == 'admin';
-        allow create: if request.resource.data.ligaId == 'BERUMEN' && request.resource.data.nombre is string;
-        allow update: if request.resource.data.ligaId == 'BERUMEN';
+        allow read: if isSignedIn() && resource.data.ligaId == 'BERUMEN';
+        allow create: if isAdmin() &&
+                      request.resource.data.ligaId == 'BERUMEN' &&
+                      request.resource.data.nombre is string;
+        allow update: if isAdmin() &&
+                      resource.data.ligaId == 'BERUMEN' &&
+                      request.resource.data.ligaId == 'BERUMEN';
+        allow delete: if isAdmin() && resource.data.ligaId == 'BERUMEN';
       }
       match /temporada/{tempId} {
         allow read: if isSignedIn();


### PR DESCRIPTION
## Summary
- allow signed-in users to read arbitros with proper liga check
- restrict create/update/delete to admins with explicit ligaId validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd6dd6fac83258cf147893a4ba65a