### PR TITLE
Fix pagos_arbitros Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -55,9 +55,12 @@ service cloud.firestore {
           }
         }
         match /pagos_arbitros/{pagoId} {
-          allow read: if isSignedIn() && ligaId == 'BERUMEN' && tempId == '2025';
-          allow create: if isSignedIn() && ligaId == 'BERUMEN' && tempId == '2025' &&
-                        get(/databases/$(database)/documents/ligas/$(ligaId)/usuarios/$(request.auth.uid)).data.role == 'admin' &&
+          allow read: if isSignedIn() &&
+                       resource.data.ligaId == 'BERUMEN' &&
+                       resource.data.tempId == '2025';
+          allow write: if isAdmin() &&
+                        request.resource.data.ligaId == 'BERUMEN' &&
+                        request.resource.data.tempId == '2025' &&
                         request.resource.data.monto > 0 &&
                         request.resource.data.arbitroId is string;
         }


### PR DESCRIPTION
## Summary
- ensure `pagos_arbitros` rules validate ligaId and tempId from document data
- restrict `pagos_arbitros` writes to admins with positive monto and arbitroId strings

## Testing
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abdcab63848325baea646d2aa4fbb2