### PR TITLE
refactor: unify firebase initialization

### DIFF
--- a/js/firebase-ui.js
+++ b/js/firebase-ui.js
@@ -1,15 +1,7 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
 import {
-  getAuth,
-  onAuthStateChanged,
-  signOut as fbSignOut,
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  setPersistence,
-  browserLocalPersistence
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
-import {
-  getFirestore,
+  auth,
+  db,
+  collection,
   doc,
   getDoc,
   getDocs,
@@ -18,28 +10,36 @@ import {
   updateDoc,
   deleteDoc,
   serverTimestamp,
-  collection,
-  getCountFromServer
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+  getCountFromServer,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged,
+  runDiag
+} from './firebase.js';
 import { LIGA_ID, TEMP_ID } from './constants.js';
+import { setPersistence, browserLocalPersistence } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 
-const firebaseConfig = {
-  apiKey: 'AIzaSyAW04kavFwGnaRJkLkHWD50WKHaxamekSU',
-  authDomain: 'berumen-sports.firebaseapp.com',
-  projectId: 'berumen-sports',
-  storageBucket: 'berumen-sports.appspot.com',
-  messagingSenderId: '718432709224',
-  appId: '1:718432709224:web:2659163e0f68c43f30a9dd'
-};
-
-export const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-// Persist authentication between tabs and reloads
 setPersistence(auth, browserLocalPersistence);
-export const db = getFirestore(app);
 
-export const signOut = () => fbSignOut(auth);
-export { signInWithEmailAndPassword, createUserWithEmailAndPassword, doc, getDoc, getDocs, setDoc, addDoc, updateDoc, deleteDoc, collection, getCountFromServer, serverTimestamp };
+export {
+  auth,
+  db,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  getCountFromServer,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  runDiag
+};
 
 export function onAuthChanged(cb){
   return onAuthStateChanged(auth, cb);
@@ -66,15 +66,3 @@ export async function userRole(){
   const snap = await getDoc(ref);
   return snap.exists()? (snap.data().role||'consulta') : 'consulta';
 }
-
-window.__FIREBASE_APP_OPTIONS__ = app.options;
-
-export async function runDiag(){
-  const deleg = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/delegaciones`));
-  const eq = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/equipos`));
-  const tarifas = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/t/${TEMP_ID}/tarifas`));
-  const partidos = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/t/${TEMP_ID}/partidos`));
-  const cobros = await getCountFromServer(collection(db, `ligas/${LIGA_ID}/t/${TEMP_ID}/cobros`));
-  console.table({delegaciones:deleg.data().count,equipos:eq.data().count,tarifas:tarifas.data().count,partidos:partidos.data().count,cobros:cobros.data().count});
-}
-window.runDiag = runDiag;


### PR DESCRIPTION
## Summary
- remove duplicate Firebase `initializeApp` usage from `firebase-ui.js`
- reuse shared app, auth, and Firestore instances via `firebase.js`
- keep UI helpers and persistence configuration without creating new Firebase instances

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abdded76fc8325b1e33af94c1e4978