### PR TITLE
Corrige encabezado sticky de tablas

### DIFF
--- a/css/berumen-theme.css
+++ b/css/berumen-theme.css
@@ -93,7 +93,7 @@ html:not(.is-mobile) .btn-primary:hover { background: var(--primary-600); }
 .table-wrap{ overflow:auto; border-radius:12px; border:1px solid var(--border); background: var(--surface); }
 table{ width:100%; border-collapse:collapse; }
 thead th{
-  position: sticky; top:0; z-index:1; text-align:left;
+  position: sticky; top:var(--topbar-h); z-index:1; text-align:left;
   background: color-mix(in srgb, var(--surface) 94%, #000 6%);
   color: var(--text); border-bottom:1px solid var(--border); padding:12px 14px; font-weight:600; font-size:14px;
 }


### PR DESCRIPTION
## Resumen
- Ajusta `thead th` para respetar `--topbar-h` y evitar que los encabezados se empalmen con la barra superior en todas las secciones.

## Testing
- `npm test` *(falla: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abe6eba3948325bf139aae51e7369f