### PR TITLE
fix: show admin action buttons consistently

### DIFF
--- a/js/views/arbitros.js
+++ b/js/views/arbitros.js
@@ -72,7 +72,8 @@ export async function render(){
         root: container,
         rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
         onEdit: ({id})=>openEdit(id),
-        onDelete: ({id})=>remove(id)
+        onDelete: ({id})=>remove(id),
+        getRole: () => role
       });
     }
     await ensureNewButton(section,{text:'Nuevo árbitro',icon:'add',onClick:openNew,fab:true});

--- a/js/views/cobros.js
+++ b/js/views/cobros.js
@@ -34,7 +34,8 @@ export async function render(){
       root: container,
       rowSelector: 'div.card[data-id]',
       onEdit: ({id})=>openEdit(id),
-      onDelete: ({id})=>remove(id)
+      onDelete: ({id})=>remove(id),
+      getRole: () => role
     });
     await ensureNewButton(section,{text:'Nuevo cobro',icon:'add',onClick:openNew,fab:true});
   }

--- a/js/views/delegaciones.js
+++ b/js/views/delegaciones.js
@@ -26,7 +26,8 @@ export async function render(){
       root: container,
       rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
       onEdit: ({id})=>openEdit(id),
-      onDelete: ({id})=>remove(id)
+      onDelete: ({id})=>remove(id),
+      getRole: () => role
     });
     await ensureNewButton(section,{text:'Nueva delegación',icon:'add',onClick:openNew,fab:true});
   }

--- a/js/views/equipos.js
+++ b/js/views/equipos.js
@@ -39,7 +39,8 @@ export async function render(){
       root: container,
       rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
       onEdit: ({id})=>openEdit(id),
-      onDelete: ({id})=>remove(id)
+      onDelete: ({id})=>remove(id),
+      getRole: () => role
     });
     await ensureNewButton(section,{text:'Nuevo equipo',icon:'add',onClick:openNew,fab:true});
   }

--- a/js/views/partidos.js
+++ b/js/views/partidos.js
@@ -37,7 +37,8 @@ export async function render(){
       root: container,
       rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
       onEdit: ({id})=>openEdit(id),
-      onDelete: ({id})=>remove(id)
+      onDelete: ({id})=>remove(id),
+      getRole: () => role
     });
     await ensureNewButton(section,{text:'Nuevo partido',icon:'add',onClick:openNew,fab:true});
   }

--- a/js/views/tarifas.js
+++ b/js/views/tarifas.js
@@ -26,7 +26,8 @@ export async function render(){
       root: container,
       rowSelector: 'tbody tr[data-id], .table-stack .row[data-id]',
       onEdit: ({id})=>openEdit(id),
-      onDelete: ({id})=>remove(id)
+      onDelete: ({id})=>remove(id),
+      getRole: () => role
     });
     await ensureNewButton(section,{text:'Nueva tarifa',icon:'add',onClick:openNew,fab:true});
   }


### PR DESCRIPTION
## Summary
- reuse cached user role when injecting row action buttons
- ensure edit/delete icons render for admins across all views

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abea927fd483258b58f4299f7a67d1