### PR TITLE
fix: remove redundant css imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,3 @@
-import './ui/tokens.css';
-import './ui/layout.css';
-import './ui/components.css';
 import './data/firebase.js';
 import { renderShell } from './core/shell.js';
 import { onAuth, login, logout, fetchUserRole } from './core/auth.js';


### PR DESCRIPTION
## Summary
- remove CSS imports from main script to prevent MIME type errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adecdd89148325af567cf89fe3b7cf