### PR TITLE
Handle Firestore permission errors when fetching user role

### DIFF
--- a/src/core/auth.js
+++ b/src/core/auth.js
@@ -21,15 +21,22 @@ export function getUserRole() {
 
 export async function fetchUserRole(uid) {
   const ref = doc(db, 'users', uid);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) {
-    await setDoc(ref, { role: 'consulta', ligaId: LIGA_ID });
+  try {
+    const snap = await getDoc(ref);
+    if (!snap.exists()) {
+      await setDoc(ref, { role: 'consulta', ligaId: LIGA_ID });
+      cachedRole = 'consulta';
+    } else {
+      cachedRole = snap.data().role;
+    }
+    localStorage.setItem('userRole', cachedRole);
+    return cachedRole;
+  } catch (err) {
+    console.error('Failed to fetch user role', err);
     cachedRole = 'consulta';
-  } else {
-    cachedRole = snap.data().role;
+    localStorage.setItem('userRole', cachedRole);
+    return cachedRole;
   }
-  localStorage.setItem('userRole', cachedRole);
-  return cachedRole;
 }
 
 export function login(email, password) {


### PR DESCRIPTION
## Summary
- handle Firestore permission failures when fetching user role by adding try/catch and defaulting role to `consulta`

## Testing
- `npm test` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f2340bc83258838fdac72b5fb1b