### PR TITLE
Cerrar menú lateral al hacer clic fuera

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -32,6 +32,9 @@ export function renderShell() {
   document.addEventListener('click', e => {
     const a = e.target.closest('a[href^="#/"]');
     if (a && a.getAttribute('href') === location.hash) e.preventDefault();
+    if (!drawer.hidden && !drawer.contains(e.target) && e.target !== menuBtn) {
+      drawer.hidden = true;
+    }
   });
   rendered = true;
 }


### PR DESCRIPTION
## Summary
- Cierra el menú lateral al hacer clic fuera de él para evitar que se superponga al contenido

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae22585fb083259e84a4f43adc9043