### PR TITLE
Handle Firestore permission errors

### DIFF
--- a/src/core/auth.js
+++ b/src/core/auth.js
@@ -33,6 +33,10 @@ export async function fetchUserRole(uid) {
     return cachedRole;
   } catch (err) {
     console.error('Failed to fetch user role', err);
+    if (err.code === 'permission-denied') {
+      await logout();
+      return null;
+    }
     cachedRole = 'consulta';
     localStorage.setItem('userRole', cachedRole);
     return cachedRole;

--- a/src/main.js
+++ b/src/main.js
@@ -18,8 +18,10 @@ onAuth(async user => {
   if (!user) {
     showLogin();
   } else {
-    await fetchUserRole(user.uid);
-    initRouter();
+    const role = await fetchUserRole(user.uid);
+    if (role) {
+      initRouter();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- Sign out when fetching user role fails with permission-denied
- Skip router initialization if user role fetch fails

## Testing
- `npm test` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b65467883259981547c7aa89eba