### PR TITLE
Hide sidebar when clicking outside or on links

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -11,6 +11,7 @@ const shellHtml = `
   <a href="#/cobros">Cobros</a>
   <a href="#/reportes">Reportes</a>
 </nav>
+<div id="drawer-overlay" hidden></div>
 <nav class="tabbar">
   <a href="#/">🏠</a>
   <a href="#/equipos">👥</a>
@@ -25,15 +26,24 @@ export function renderShell() {
   document.body.insertAdjacentHTML('afterbegin', shellHtml);
   const menuBtn = document.getElementById('menu-btn');
   const drawer = document.getElementById('drawer');
-  menuBtn.addEventListener('click', () => drawer.hidden = !drawer.hidden);
+  const overlay = document.getElementById('drawer-overlay');
+  function closeDrawer() {
+    drawer.hidden = true;
+    overlay.hidden = true;
+  }
+  menuBtn.addEventListener('click', () => {
+    drawer.hidden = !drawer.hidden;
+    overlay.hidden = drawer.hidden;
+  });
+  overlay.addEventListener('click', closeDrawer);
   drawer.addEventListener('click', e => {
-    if (e.target.tagName === 'A') drawer.hidden = true;
+    if (e.target.closest('a')) closeDrawer();
   });
   document.addEventListener('click', e => {
     const a = e.target.closest('a[href^="#/"]');
     if (a && a.getAttribute('href') === location.hash) e.preventDefault();
     if (!drawer.hidden && !drawer.contains(e.target) && e.target !== menuBtn) {
-      drawer.hidden = true;
+      closeDrawer();
     }
   });
   rendered = true;

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -36,6 +36,16 @@ body {
   z-index: 950;
 }
 
+#drawer-overlay {
+  position: fixed;
+  top: 56px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 940;
+}
+
 #drawer a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- add overlay and event handlers so sidebar closes when clicking links or outside
- style overlay to cover content when menu open

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5cb19c8c832595e62b11bd086063