### PR TITLE
Fix sidebar staying open over content

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -46,5 +46,6 @@ export function renderShell() {
       closeDrawer();
     }
   });
+  window.addEventListener('hashchange', closeDrawer);
   rendered = true;
 }

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -3,6 +3,9 @@ body {
   background: var(--color-bg);
   color: var(--color-text);
 }
+[hidden] {
+  display: none !important;
+}
 #app {
   padding-top: 56px;
   padding-bottom: 56px;


### PR DESCRIPTION
## Summary
- Ensure the sidebar closes whenever the location hash changes to avoid it persisting over content
- Add `[hidden]` CSS rule so hidden elements are not displayed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5e19f5888325bb14183f5cc891ed