### PR TITLE
fix: prevent safeWrite from accessing undefined

### DIFF
--- a/src/data/repo.js
+++ b/src/data/repo.js
@@ -4,7 +4,7 @@ import { LIGA_ID, TEMP_ID, paths } from './paths.js';
 async function safeWrite(cb, label) {
   try {
     const res = await cb();
-    console.log(`OK ${label}:`, res.id || res);
+    console.log(`OK ${label}:`, res?.id ?? res);
     return res;
   } catch (e) {
     console.error(`FALLÓ ${label}:`, e.message);


### PR DESCRIPTION
## Summary
- avoid accessing `id` on undefined results in `safeWrite`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f964b608325965e1124b2b5f33b