### PR TITLE
Add missing Firestore index for delegaciones

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -39,6 +39,14 @@
         {"fieldPath":"pagado","order":"ASCENDING"},
         {"fieldPath":"fechaCobro","order":"DESCENDING"}
       ]
+    },
+    {
+      "collectionGroup": "delegaciones",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"nombre","order":"ASCENDING"}
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add composite index for delegaciones to support ligaId filter and nombre ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae62fa78a883258ec3a4f77090ce1f