### PR TITLE
Estandariza diseño de ventanas modales

### DIFF
--- a/src/core/modal-manager.js
+++ b/src/core/modal-manager.js
@@ -1,21 +1,26 @@
 let modal;
 export function openModal(content) {
+  const tabbar = document.querySelector('.tabbar');
+  const mb = tabbar && getComputedStyle(tabbar).display !== 'none' ? tabbar.offsetHeight : 0;
   if (!modal) {
     modal = document.createElement('div');
     modal.id = 'modal';
     Object.assign(modal.style, {
-      position: 'fixed', top:0,left:0,right:0,bottom:0,
-      background:'rgba(0,0,0,0.3)',display:'flex',
-      alignItems:'center',justifyContent:'center',zIndex:1100
+      position: 'fixed', top: 0, left: 0, right: 0,
+      background: 'rgba(0,0,0,0.3)', display: 'flex',
+      alignItems: 'flex-end', justifyContent: 'center', zIndex: 1100
     });
     modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
     document.getElementById('modal-root').appendChild(modal);
   }
-  modal.innerHTML = `<div style="background:#fff;max-height:90vh;overflow:auto;padding:1rem;border-radius:var(--radius);">${content}</div>`;
+  modal.style.display = 'flex';
+  modal.style.bottom = mb + 'px';
+  modal.innerHTML = `<div class="modal-sheet">${content}</div>`;
   document.body.style.overflow = 'hidden';
 }
 export function closeModal() {
   if (!modal) return;
   modal.innerHTML = '';
+  modal.style.display = 'none';
   document.body.style.overflow = '';
 }

--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -17,7 +17,7 @@ export async function render(el) {
   if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openArbitro());
 }
 function openArbitro() {
-  openModal(`<form id="ar-form"><input name="nombre" placeholder="Nombre"><button>Guardar</button></form>`);
+  openModal(`<form id="ar-form" class="modal-form"><input name="nombre" placeholder="Nombre"><button>Guardar</button></form>`);
   document.getElementById('ar-form').addEventListener('submit', async e => {
     e.preventDefault();
     await addArbitro({ nombre: e.target.nombre.value });

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -17,7 +17,7 @@ export async function render(el) {
   if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openCobro());
 }
 function openCobro() {
-  openModal(`<form id="co-form"><input name="partido" placeholder="PartidoId"><input name="monto" type="number" placeholder="Monto"><button>Guardar</button></form>`);
+  openModal(`<form id="co-form" class="modal-form"><input name="partido" placeholder="PartidoId"><input name="monto" type="number" placeholder="Monto"><button>Guardar</button></form>`);
   document.getElementById('co-form').addEventListener('submit', async e => {
     e.preventDefault();
     await addCobro({ partidoId: e.target.partido.value, monto: Number(e.target.monto.value), pagado:false });

--- a/src/features/delegaciones.js
+++ b/src/features/delegaciones.js
@@ -23,7 +23,7 @@ export async function render(el) {
 
 function openDelegacion(id) {
   const isEdit = !!id;
-  openModal(`<form id="del-form"><input name="nombre" placeholder="Nombre"><button>Guardar</button></form>`);
+  openModal(`<form id="del-form" class="modal-form"><input name="nombre" placeholder="Nombre"><button>Guardar</button></form>`);
   const form = document.getElementById('del-form');
   form.addEventListener('submit', async e => {
     e.preventDefault();

--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -32,7 +32,7 @@ function openEquipo(id, delegaciones) {
   const ramaOpts = ['Varonil','Femenil'].map(r => `<option value="${r}">${r}</option>`).join('');
   const catOpts = Array.from({length: 2020-2009+1}, (_,i)=>2009+i).map(y => `<option value="${y}">${y}</option>`).join('');
   const delOpts = Object.entries(delegaciones).map(([did,name]) => `<option value="${did}">${name}</option>`).join('');
-  openModal(`<form id="eq-form"><input name="nombre" placeholder="Nombre"><select name="rama">${ramaOpts}</select><select name="categoria">${catOpts}</select><select name="delegacionId">${delOpts}</select><button>Guardar</button></form>`);
+  openModal(`<form id="eq-form" class="modal-form"><input name="nombre" placeholder="Nombre"><select name="rama">${ramaOpts}</select><select name="categoria">${catOpts}</select><select name="delegacionId">${delOpts}</select><button>Guardar</button></form>`);
   const form = document.getElementById('eq-form');
   form.addEventListener('submit', async e => {
     e.preventDefault();

--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -17,7 +17,7 @@ export async function render(el) {
   if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openPartido());
 }
 function openPartido() {
-  openModal(`<form id="pa-form"><input name="fecha" type="date"><input name="local" placeholder="Local"><input name="visita" placeholder="Visita"><button>Guardar</button></form>`);
+  openModal(`<form id="pa-form" class="modal-form"><input name="fecha" type="date"><input name="local" placeholder="Local"><input name="visita" placeholder="Visita"><button>Guardar</button></form>`);
   document.getElementById('pa-form').addEventListener('submit', async e => {
     e.preventDefault();
     await addPartido({ fecha: new Date(e.target.fecha.value), localId: e.target.local.value, visitaId: e.target.visita.value });

--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -19,3 +19,23 @@ input, select {
   padding:var(--space);
   margin:var(--space) 0;
 }
+
+.modal-sheet {
+  background:#fff;
+  width:100%;
+  border-radius:var(--radius) var(--radius) 0 0;
+  box-shadow:var(--shadow);
+  padding:var(--space);
+  max-height:90%;
+  overflow:auto;
+}
+
+.modal-form {
+  display:flex;
+  flex-direction:column;
+  gap:var(--space);
+}
+
+.modal-form > * {
+  width:100%;
+}


### PR DESCRIPTION
## Summary
- Implement bottom sheet modal that evita superponer el tabbar y cierra al tocar el fondo
- Agrega estilos `.modal-sheet` y `.modal-form` para contenido con esquinas redondeadas y campos apilados
- Actualiza todas las vistas de creación/edición para usar el nuevo estilo de formularios

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ae65f8c42c832590e72435f3e8d447