### PR TITLE
Filtra equipos por rama y categoría en modal de partidos

### DIFF
--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, getDocs } from '../data/firebase.js';
 import { paths, LIGA_ID, TEMP_ID } from '../data/paths.js';
 import { addPartido } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -16,11 +16,56 @@ export async function render(el) {
   pushCleanup(() => unsub());
   if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openPartido());
 }
-function openPartido() {
-  openModal(`<form id="pa-form" class="modal-form"><input name="fecha" type="date"><input name="local" placeholder="Local"><input name="visita" placeholder="Visita"><button>Guardar</button></form>`);
-  document.getElementById('pa-form').addEventListener('submit', async e => {
+async function openPartido() {
+  const [eqSnap, arSnap] = await Promise.all([
+    getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID), orderBy('nombre'))),
+    getDocs(query(collection(db, paths.arbitros()), where('ligaId','==',LIGA_ID), orderBy('nombre'))),
+  ]);
+  const equipos = eqSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+  const ramas = [...new Set(equipos.map(e => e.rama).filter(Boolean))];
+  const categorias = [...new Set(equipos.map(e => e.categoria).filter(Boolean))];
+  const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
+  const catOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+  const arOpts = arSnap.docs.map(d => `<option value="${d.id}">${d.data().nombre}</option>`).join('');
+  openModal(`<form id="pa-form" class="modal-form">
+    <input name="fecha" type="datetime-local">
+    <select name="rama"><option value="">Rama</option>${ramaOpts}</select>
+    <select name="categoria"><option value="">Categoría</option>${catOpts}</select>
+    <select name="local" hidden disabled></select>
+    <select name="visita" hidden disabled></select>
+    <select name="arbitro" hidden><option value="">Árbitro</option>${arOpts}</select>
+    <button>Guardar</button>
+  </form>`);
+  const form = document.getElementById('pa-form');
+  function updateEquipos() {
+    const r = form.rama.value;
+    const c = form.categoria.value;
+    if (r && c) {
+      const filtered = equipos.filter(e => e.rama === r && e.categoria === c);
+      const opts = filtered.map(e => `<option value="${e.id}">${e.nombre}</option>`).join('');
+      form.local.innerHTML = opts;
+      form.visita.innerHTML = opts;
+      form.local.hidden = form.visita.hidden = false;
+      form.local.disabled = form.visita.disabled = false;
+      form.arbitro.hidden = false;
+    } else {
+      form.local.hidden = form.visita.hidden = true;
+      form.local.disabled = form.visita.disabled = true;
+      form.arbitro.hidden = true;
+    }
+  }
+  form.rama.addEventListener('change', updateEquipos);
+  form.categoria.addEventListener('change', updateEquipos);
+  form.addEventListener('submit', async e => {
     e.preventDefault();
-    await addPartido({ fecha: new Date(e.target.fecha.value), localId: e.target.local.value, visitaId: e.target.visita.value });
+    await addPartido({
+      fecha: new Date(form.fecha.value),
+      rama: form.rama.value,
+      categoria: form.categoria.value,
+      localId: form.local.value,
+      visitaId: form.visita.value,
+      arbitroId: form.arbitro.value,
+    });
     closeModal();
   });
 }


### PR DESCRIPTION
## Summary
- Activa un modal de partidos con campos de fecha/hora, rama y categoría
- Habilita y filtra equipos locales y visitantes según rama y categoría seleccionadas
- Permite elegir árbitro del partido antes de guardar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6ad4b55c8325b10c048e76d73b35