### PR TITLE
Show authenticated user's name and role in topbar

### DIFF
--- a/src/core/auth.js
+++ b/src/core/auth.js
@@ -11,6 +11,7 @@ import {
 
 const LIGA_ID = 'BERUMEN';
 let cachedRole = null;
+let cachedName = null;
 
 export function getUserRole() {
   if (cachedRole) return cachedRole;
@@ -19,18 +20,21 @@ export function getUserRole() {
   return null;
 }
 
-export async function fetchUserRole(uid) {
+export async function fetchUserInfo(uid) {
   const ref = doc(db, 'users', uid);
   try {
     const snap = await getDoc(ref);
     if (!snap.exists()) {
       await setDoc(ref, { role: 'consulta', ligaId: LIGA_ID });
       cachedRole = 'consulta';
+      cachedName = '';
     } else {
-      cachedRole = snap.data().role;
+      const data = snap.data();
+      cachedRole = data.role;
+      cachedName = data.nombre || '';
     }
     localStorage.setItem('userRole', cachedRole);
-    return cachedRole;
+    return { role: cachedRole, nombre: cachedName };
   } catch (err) {
     console.error('Failed to fetch user role', err);
     if (err.code === 'permission-denied') {
@@ -38,8 +42,9 @@ export async function fetchUserRole(uid) {
       return null;
     }
     cachedRole = 'consulta';
+    cachedName = '';
     localStorage.setItem('userRole', cachedRole);
-    return cachedRole;
+    return { role: cachedRole, nombre: cachedName };
   }
 }
 

--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -1,7 +1,8 @@
 const shellHtml = `
 <header class="topbar">
   <button id="menu-btn" aria-label="Menu">☰</button>
-  <h1 style="margin-left:1rem; font-size:1.2rem;">Berumen</h1>
+  <div id="user-info" class="topbar-title">Berumen</div>
+  <button id="logout-btn" onclick="appLogout()" aria-label="Cerrar sesión" hidden>⎋</button>
 </header>
 <nav id="drawer" hidden>
   <a href="#/">Home</a>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import './data/firebase.js';
 import { renderShell } from './core/shell.js';
-import { onAuth, login, logout, fetchUserRole } from './core/auth.js';
+import { onAuth, login, logout, fetchUserInfo } from './core/auth.js';
 import { initRouter } from './core/router.js';
 
 function hideShell() {
@@ -26,11 +26,19 @@ onAuth(async user => {
   if (!user) {
     hideShell();
     showLogin();
+    const userInfoEl = document.getElementById('user-info');
+    const logoutBtn = document.getElementById('logout-btn');
+    if (userInfoEl) userInfoEl.textContent = 'Berumen';
+    if (logoutBtn) logoutBtn.hidden = true;
   } else {
     renderShell();
     showShell();
-    const role = await fetchUserRole(user.uid);
-    if (role) {
+    const info = await fetchUserInfo(user.uid);
+    if (info) {
+      const userInfoEl = document.getElementById('user-info');
+      const logoutBtn = document.getElementById('logout-btn');
+      if (userInfoEl) userInfoEl.textContent = `${info.nombre} - ${info.role}`;
+      if (logoutBtn) logoutBtn.hidden = false;
       initRouter();
     }
   }

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -24,6 +24,12 @@ body {
   z-index: 1000;
 }
 
+.topbar-title {
+  flex: 1;
+  text-align: center;
+  font-size: 1.2rem;
+}
+
 #drawer {
   position: fixed;
   top: 56px;


### PR DESCRIPTION
## Summary
- Render user name and role in the top bar when logged in and add logout button
- Fetch user info from Firestore and update shell accordingly
- Style top bar title to center its content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6c7e78f8832591ca01762dea2291