### PR TITLE
feat: add tarifas section to manage match fees

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -47,6 +47,15 @@
         {"fieldPath":"ligaId","order":"ASCENDING"},
         {"fieldPath":"nombre","order":"ASCENDING"}
       ]
+    },
+    {
+      "collectionGroup": "tarifas",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"rama","order":"ASCENDING"},
+        {"fieldPath":"categoria","order":"ASCENDING"}
+      ]
     }
   ],
   "fieldOverrides": []

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -5,6 +5,7 @@ const routes = {
   '/arbitros': () => import('../features/arbitros.js'),
   '/partidos': () => import('../features/partidos.js'),
   '/cobros': () => import('../features/cobros.js'),
+  '/tarifas': () => import('../features/tarifas.js'),
   '/reportes': () => import('../features/reportes.js'),
 };
 

--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -11,6 +11,7 @@ const shellHtml = `
   <a href="#/arbitros">Árbitros</a>
   <a href="#/partidos">Partidos</a>
   <a href="#/cobros">Cobros</a>
+  <a href="#/tarifas">Tarifas</a>
   <a href="#/reportes">Reportes</a>
 </nav>
 <div id="drawer-overlay" hidden></div>

--- a/src/data/repo.js
+++ b/src/data/repo.js
@@ -42,6 +42,9 @@ export function updatePartido(id, data) {
 export function addCobro(data) {
   return safeWrite(() => addDoc(collection(db, paths.cobros()), { ...data, ligaId: LIGA_ID, tempId: TEMP_ID }), 'addCobro');
 }
+export function addTarifa(data) {
+  return safeWrite(() => addDoc(collection(db, paths.tarifas()), { ...data, ligaId: LIGA_ID }), 'addTarifa');
+}
 export function addDiagnostic(note, byUid) {
   return safeWrite(() => addDoc(collection(db, paths.diagnostics()), { note, byUid, createdAt: Date.now(), ligaId: LIGA_ID }), 'addDiagnostic');
 }

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -1,0 +1,46 @@
+import { db, collection, query, where, onSnapshot, orderBy, getDocs } from '../data/firebase.js';
+import { paths, LIGA_ID } from '../data/paths.js';
+import { addTarifa } from '../data/repo.js';
+import { openModal, closeModal } from '../core/modal-manager.js';
+import { pushCleanup } from '../core/router.js';
+import { getUserRole } from '../core/auth.js';
+
+export async function render(el) {
+  const isAdmin = getUserRole() === 'admin';
+  el.innerHTML = `<div class="card"><h2>Tarifas</h2>${isAdmin?'<button id="nuevo">Nuevo</button>':''}<ul id="list"></ul></div>`;
+  const q = query(collection(db, paths.tarifas()), where('ligaId','==',LIGA_ID), orderBy('rama'), orderBy('categoria'));
+  const unsub = onSnapshot(q, snap => {
+    const rows = snap.docs.map(d => {
+      const data = d.data();
+      const monto = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0}).format(data.tarifa);
+      return `<li>${data.rama} - ${data.categoria}: ${monto}</li>`;
+    }).join('');
+    document.getElementById('list').innerHTML = rows || '<li>No hay tarifas</li>';
+  });
+  pushCleanup(() => unsub());
+  if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openTarifa());
+}
+
+async function openTarifa() {
+  const eqSnap = await getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID)));
+  const equipos = eqSnap.docs.map(d => d.data());
+  const ramas = [...new Set(equipos.map(e => e.rama).filter(Boolean))];
+  const categorias = [...new Set(equipos.map(e => e.categoria).filter(Boolean))];
+  const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
+  const catOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+  openModal(`<form id="ta-form" class="modal-form">
+    <select name="rama"><option value="">Rama</option>${ramaOpts}</select>
+    <select name="categoria"><option value="">Categoría</option>${catOpts}</select>
+    <input name="tarifa" type="number" min="0" step="1" placeholder="Tarifa">
+    <button>Guardar</button>
+  </form>`);
+  document.getElementById('ta-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    await addTarifa({
+      rama: e.target.rama.value,
+      categoria: e.target.categoria.value,
+      tarifa: Number(e.target.tarifa.value),
+    });
+    closeModal();
+  });
+}


### PR DESCRIPTION
## Summary
- add `addTarifa` repo function and firestore index
- create tarifas feature with modal form for rama, categoría and MXN tariff
- expose tarifas via new route and navigation link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ee4811883258874b0abaaaf0cc0