### PR TITLE
feat: calcular tarifa y monto en cobros

### DIFF
--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, getDocs } from '../data/firebase.js';
 import { paths, LIGA_ID, TEMP_ID } from '../data/paths.js';
 import { addCobro } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -8,19 +8,66 @@ import { getUserRole } from '../core/auth.js';
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
   el.innerHTML = `<div class="card"><h2>Cobros</h2>${isAdmin?'<button id="nuevo">Nuevo</button>':''}<ul id="list"></ul></div>`;
-  const q = query(collection(db, paths.cobros()), where('ligaId','==',LIGA_ID), where('tempId','==',TEMP_ID), orderBy('fechaCobro','desc'));
+  const fmt = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0});
+  const q = query(
+    collection(db, paths.cobros()),
+    where('ligaId','==',LIGA_ID),
+    where('tempId','==',TEMP_ID),
+    orderBy('fechaCobro','desc')
+  );
   const unsub = onSnapshot(q, snap => {
-    const rows = snap.docs.map(d => `<li>${d.data().partidoId || ''} - $${d.data().monto}</li>`).join('');
+    const rows = snap.docs.map(d => {
+      const data = d.data();
+      return `<li>${data.partidoId || ''} - ${fmt.format(data.monto)}</li>`;
+    }).join('');
     document.getElementById('list').innerHTML = rows || '<li>No hay cobros</li>';
   });
   pushCleanup(() => unsub());
   if (isAdmin) document.getElementById('nuevo').addEventListener('click', () => openCobro());
 }
-function openCobro() {
-  openModal(`<form id="co-form" class="modal-form"><input name="partido" placeholder="PartidoId"><input name="monto" type="number" placeholder="Monto"><button>Guardar</button></form>`);
-  document.getElementById('co-form').addEventListener('submit', async e => {
+
+async function openCobro() {
+  const [paSnap, taSnap] = await Promise.all([
+    getDocs(query(
+      collection(db, paths.partidos()),
+      where('ligaId','==',LIGA_ID),
+      where('tempId','==',TEMP_ID),
+      orderBy('fecha','desc')
+    )),
+    getDocs(query(collection(db, paths.tarifas()), where('ligaId','==',LIGA_ID)))
+  ]);
+  const partidos = paSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+  const tarifas = taSnap.docs.map(d => d.data());
+  const paOpts = partidos.map(p => `<option value="${p.id}" data-rama="${p.rama}" data-categoria="${p.categoria}">${p.localId} vs ${p.visitaId}</option>`).join('');
+  openModal(`<form id="co-form" class="modal-form">
+    <select name="partido"><option value="">Partido</option>${paOpts}</select>
+    <input name="tarifa" placeholder="Tarifa" disabled>
+    <input name="monto" type="number" min="0" step="1" placeholder="Cobro">
+    <button>Guardar</button>
+  </form>`);
+  const form = document.getElementById('co-form');
+  const fmt = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0});
+  function updateTarifa() {
+    const opt = form.partido.selectedOptions[0];
+    if (!opt) {
+      form.tarifa.value = '';
+      form.tarifa.dataset.raw = '';
+      return;
+    }
+    const tarifa = tarifas.find(t => t.rama === opt.dataset.rama && t.categoria === opt.dataset.categoria)?.tarifa || 0;
+    form.tarifa.value = fmt.format(tarifa);
+    form.tarifa.dataset.raw = tarifa;
+  }
+  form.partido.addEventListener('change', updateTarifa);
+  form.addEventListener('submit', async e => {
     e.preventDefault();
-    await addCobro({ partidoId: e.target.partido.value, monto: Number(e.target.monto.value), pagado:false });
+    await addCobro({
+      partidoId: form.partido.value,
+      tarifa: Number(form.tarifa.dataset.raw || 0),
+      monto: Number(form.monto.value),
+      pagado:false,
+      fechaCobro: new Date(),
+    });
     closeModal();
   });
 }


### PR DESCRIPTION
## Summary
- Asignar automáticamente la tarifa de un partido según su rama y categoría
- Mostrar la tarifa y registrar cobros en formato MXN sin decimales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae728d5ab4832582b5449f325cba27