### PR TITLE
Add edit/delete actions to record lists

### DIFF
--- a/src/data/repo.js
+++ b/src/data/repo.js
@@ -33,17 +33,38 @@ export function deleteDelegacion(id) {
 export function addArbitro(data) {
   return safeWrite(() => addDoc(collection(db, paths.arbitros()), { ...data, ligaId: LIGA_ID }), 'addArbitro');
 }
+export function updateArbitro(id, data) {
+  return safeWrite(() => updateDoc(doc(db, paths.arbitros(), id), data), 'updateArbitro');
+}
+export function deleteArbitro(id) {
+  return safeWrite(() => deleteDoc(doc(db, paths.arbitros(), id)), 'deleteArbitro');
+}
 export function addPartido(data) {
   return safeWrite(() => addDoc(collection(db, paths.partidos()), { ...data, ligaId: LIGA_ID, tempId: TEMP_ID }), 'addPartido');
 }
 export function updatePartido(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.partidos(), id), data), 'updatePartido');
 }
+export function deletePartido(id) {
+  return safeWrite(() => deleteDoc(doc(db, paths.partidos(), id)), 'deletePartido');
+}
 export function addCobro(data) {
   return safeWrite(() => addDoc(collection(db, paths.cobros()), { ...data, ligaId: LIGA_ID, tempId: TEMP_ID }), 'addCobro');
 }
+export function updateCobro(id, data) {
+  return safeWrite(() => updateDoc(doc(db, paths.cobros(), id), data), 'updateCobro');
+}
+export function deleteCobro(id) {
+  return safeWrite(() => deleteDoc(doc(db, paths.cobros(), id)), 'deleteCobro');
+}
 export function addTarifa(data) {
   return safeWrite(() => addDoc(collection(db, paths.tarifas()), { ...data, ligaId: LIGA_ID }), 'addTarifa');
+}
+export function updateTarifa(id, data) {
+  return safeWrite(() => updateDoc(doc(db, paths.tarifas(), id), data), 'updateTarifa');
+}
+export function deleteTarifa(id) {
+  return safeWrite(() => deleteDoc(doc(db, paths.tarifas(), id)), 'deleteTarifa');
 }
 export function addDiagnostic(note, byUid) {
   return safeWrite(() => addDoc(collection(db, paths.diagnostics()), { note, byUid, createdAt: Date.now(), ligaId: LIGA_ID }), 'addDiagnostic');


### PR DESCRIPTION
## Summary
- add update/delete methods for arbitros, partidos, cobros and tarifas
- render edit/delete icons in lists for arbitros, cobros, partidos and tarifas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae83839bf08325be390e69a92a90bf