### PR TITLE
Preload current values when editing records

### DIFF
--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, doc, getDoc } from '../data/firebase.js';
 import { paths, LIGA_ID } from '../data/paths.js';
 import { addArbitro, updateArbitro, deleteArbitro } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -45,8 +45,13 @@ function formatPhone(value) {
   return `(${digits.slice(0,3)}) ${digits.slice(3,6)} ${digits.slice(6)}`;
 }
 
-function openArbitro(id) {
+async function openArbitro(id) {
   const isEdit = !!id;
+  let existing = { nombre: '', telefono: '', email: '' };
+  if (isEdit) {
+    const snap = await getDoc(doc(db, paths.arbitros(), id));
+    if (snap.exists()) existing = snap.data();
+  }
   openModal(`
     <form id="ar-form" class="modal-form">
       <label class="field"><span class="label">Nombre</span><input name="nombre" class="input" required></label>
@@ -55,6 +60,9 @@ function openArbitro(id) {
       <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="closeModal()">Cancelar</button><button class="btn btn-primary">Guardar</button></div>
     </form>`);
   const form = document.getElementById('ar-form');
+  form.nombre.value = existing.nombre || '';
+  form.telefono.value = existing.telefono || '';
+  form.email.value = existing.email || '';
   form.addEventListener('submit', async e => {
     e.preventDefault();
     const data = {

--- a/src/features/delegaciones.js
+++ b/src/features/delegaciones.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, doc, getDoc } from '../data/firebase.js';
 import { paths, LIGA_ID } from '../data/paths.js';
 import { addDelegacion, updateDelegacion, deleteDelegacion } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -21,10 +21,16 @@ export async function render(el) {
   }
 }
 
-function openDelegacion(id) {
+async function openDelegacion(id) {
   const isEdit = !!id;
+  let existing = { nombre: '' };
+  if (isEdit) {
+    const snap = await getDoc(doc(db, paths.delegaciones(), id));
+    if (snap.exists()) existing = snap.data();
+  }
   openModal(`<form id="del-form" class="modal-form"><label class="field"><span class="label">Nombre</span><input class="input" name="nombre" placeholder="Nombre"></label><div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="closeModal()">Cancelar</button><button class="btn btn-primary">Guardar</button></div></form>`);
   const form = document.getElementById('del-form');
+  form.nombre.value = existing.nombre || '';
   form.addEventListener('submit', async e => {
     e.preventDefault();
     const data = { nombre: form.nombre.value };

--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy, getDocs } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, getDocs, doc, getDoc } from '../data/firebase.js';
 import { paths, LIGA_ID } from '../data/paths.js';
 import { addEquipo, updateEquipo, deleteEquipo } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -27,8 +27,13 @@ export async function render(el) {
   }
 }
 
-function openEquipo(id, delegaciones) {
+async function openEquipo(id, delegaciones) {
   const isEdit = !!id;
+  let existing = { nombre: '', rama: '', categoria: '', delegacionId: '' };
+  if (isEdit) {
+    const snap = await getDoc(doc(db, paths.equipos(), id));
+    if (snap.exists()) existing = snap.data();
+  }
   const ramaOpts = ['Varonil','Femenil'].map(r => `<option value="${r}">${r}</option>`).join('');
   const catOpts = Array.from({length: 2020-2009+1}, (_,i)=>2009+i).map(y => `<option value="${y}">${y}</option>`).join('');
   const delOpts = Object.entries(delegaciones).map(([did,name]) => `<option value="${did}">${name}</option>`).join('');
@@ -40,6 +45,10 @@ function openEquipo(id, delegaciones) {
     <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="closeModal()">Cancelar</button><button class="btn btn-primary">Guardar</button></div>
   </form>`);
   const form = document.getElementById('eq-form');
+  form.nombre.value = existing.nombre || '';
+  form.rama.value = existing.rama || '';
+  form.categoria.value = existing.categoria || '';
+  form.delegacionId.value = existing.delegacionId || '';
   form.addEventListener('submit', async e => {
     e.preventDefault();
     const data = { nombre: form.nombre.value, rama: form.rama.value, categoria: form.categoria.value, delegacionId: form.delegacionId.value };

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -1,4 +1,4 @@
-import { db, collection, query, where, onSnapshot, orderBy, getDocs } from '../data/firebase.js';
+import { db, collection, query, where, onSnapshot, orderBy, getDocs, doc, getDoc } from '../data/firebase.js';
 import { paths, LIGA_ID } from '../data/paths.js';
 import { addTarifa, updateTarifa, deleteTarifa } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
@@ -41,24 +41,32 @@ export async function render(el) {
 
 async function openTarifa(id) {
   const isEdit = !!id;
-  const eqSnap = await getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID)));
+  const [eqSnap, taSnap] = await Promise.all([
+    getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID))),
+    isEdit ? getDoc(doc(db, paths.tarifas(), id)) : Promise.resolve(null)
+  ]);
   const equipos = eqSnap.docs.map(d => d.data());
   const ramas = [...new Set(equipos.map(e => e.rama).filter(Boolean))];
   const categorias = [...new Set(equipos.map(e => e.categoria).filter(Boolean))];
   const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
   const catOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+  const existing = taSnap?.exists() ? taSnap.data() : { rama: '', categoria: '', tarifa: '' };
   openModal(`<form id="ta-form" class="modal-form">
     <label class="field"><span class="label">Rama</span><select name="rama" class="input"><option value="">Rama</option>${ramaOpts}</select></label>
     <label class="field"><span class="label">Categoría</span><select name="categoria" class="input"><option value="">Categoría</option>${catOpts}</select></label>
     <label class="field"><span class="label">Monto</span><input name="tarifa" type="number" min="0" step="1" class="input" placeholder="Tarifa"></label>
     <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="closeModal()">Cancelar</button><button class="btn btn-primary">Guardar</button></div>
   </form>`);
-  document.getElementById('ta-form').addEventListener('submit', async e => {
+  const form = document.getElementById('ta-form');
+  form.rama.value = existing.rama || '';
+  form.categoria.value = existing.categoria || '';
+  form.tarifa.value = existing.tarifa || '';
+  form.addEventListener('submit', async e => {
     e.preventDefault();
     const data = {
-      rama: e.target.rama.value,
-      categoria: e.target.categoria.value,
-      tarifa: Number(e.target.tarifa.value),
+      rama: form.rama.value,
+      categoria: form.categoria.value,
+      tarifa: Number(form.tarifa.value),
     };
     if (isEdit) await updateTarifa(id, data); else await addTarifa(data);
     closeModal();


### PR DESCRIPTION
## Summary
- Load existing record data into edit modals for all features
- Allow users to update entries with prefilled forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae856881bc8325aae28f4e82f64d0b