### PR TITLE
Fix timezone offset in match editor

### DIFF
--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -96,7 +96,13 @@ async function openPartido(id) {
   form.rama.addEventListener('change', updateEquipos);
   form.categoria.addEventListener('change', updateEquipos);
   if (isEdit) {
-    form.fecha.value = existing.fecha ? new Date(existing.fecha.seconds * 1000).toISOString().slice(0,16) : '';
+    if (existing.fecha) {
+      const date = new Date(existing.fecha.seconds * 1000);
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+      form.fecha.value = date.toISOString().slice(0, 16);
+    } else {
+      form.fecha.value = '';
+    }
     form.rama.value = existing.rama || '';
     form.categoria.value = existing.categoria || '';
     updateEquipos();


### PR DESCRIPTION
## Summary
- fix incorrect date/time when editing a match by adjusting for timezone offset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8c7668188325b82840d8009e601a