### PR TITLE
feat: add cobro status grouping

### DIFF
--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -90,6 +90,9 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
   line-height:1.6;
 }
 .badge { background: var(--color-surface-elevated); color: var(--color-text-muted); }
+.badge-success { background: var(--color-success); color:#fff; }
+.badge-warning { background: var(--color-warning); color:#fff; }
+.badge-danger { background: var(--color-danger); color:#fff; }
 
 /* FAB */
 .fab {


### PR DESCRIPTION
## Summary
- show payment status badge for each cobro
- group cobros into pending, partial and paid sections
- add colored badge styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f60ce448325887a637198c8ff85