### PR TITLE
Fix Chart.js import in reports feature

### DIFF
--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -3,7 +3,7 @@ import { paths, LIGA_ID, TEMP_ID } from '../data/paths.js';
 
 export async function render(el) {
   const chartJs = await import('https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js');
-  const { Chart } = chartJs;
+  const { default: Chart } = chartJs;
 
   el.innerHTML = `
     <div class="card">


### PR DESCRIPTION
## Summary
- import Chart.js default export to access constructor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae969b30048325a58bb5c78ae5f90e