### PR TITLE
Limit modal width on desktop

### DIFF
--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -140,6 +140,15 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
 .modal-footer { display:flex; justify-content:flex-end; gap:var(--space-3); margin-top:var(--space-4); }
 .modal-form { display:flex; flex-direction:column; gap:var(--space-4); }
 
+@media (min-width:1024px) {
+  .modal-sheet {
+    max-width:30vw;
+    left:50%;
+    right:auto;
+    transform:translateX(-50%);
+  }
+}
+
 /* Row actions */
 .row-actions { display:flex; gap:var(--space-2); }
 


### PR DESCRIPTION
## Summary
- Constrain modal width to 30% of viewport on desktop screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af27f84798832593c8676fe161c979