### PR TITLE
Responsive tables with card layout for mobile lists

### DIFF
--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -18,16 +18,22 @@ export async function render(el) {
         <input id="buscar" class="input" placeholder="Buscar">
         <button id="limpiar" class="btn btn-secondary">Limpiar</button>
       </div>
-      <table id="list"></table>
+      <table class="responsive-table"><thead><tr><th>Nombre</th><th>Teléfono</th><th>Email</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
     </div>
     ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo árbitro"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   const q = query(collection(db, paths.arbitros()), where('ligaId','==',LIGA_ID), orderBy('nombre'));
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => {
       const data = d.data();
-      return `<tr><td>${data.nombre}</td><td>${data.telefono||''}</td><td>${data.email||''}</td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`;
+      return `<tr>
+        <td data-label="Nombre">${data.nombre}</td>
+        <td data-label="Teléfono">${data.telefono||''}</td>
+        <td data-label="Email">${data.email||''}</td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
+      </tr>`;
     }).join('');
-    document.getElementById('list').innerHTML = rows || '<tr><td>No hay árbitros</td></tr>';
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?4:3}">No hay árbitros</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
   });
   pushCleanup(() => unsub());
   if (isAdmin) {

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -55,12 +55,18 @@ export async function render(el) {
       if (!monto) { status = 'Pendiente'; badgeClass = 'badge-danger'; }
       else if (monto < tarifa) { status = 'Pago parcial'; badgeClass = 'badge-warning'; }
       else { status = 'Pagado'; badgeClass = 'badge-success'; }
-      const row = `<tr><td>${pa.rama || ''} ${pa.categoria || ''} - ${local} vs ${visita} - ${fecha}</td><td>${fmt.format(tarifa)}</td><td>${fmt.format(monto)}</td><td><span class="badge ${badgeClass}">${status}</span></td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`;
+      const row = `<tr>
+        <td data-label="Partido">${pa.rama || ''} ${pa.categoria || ''} - ${local} vs ${visita} - ${fecha}</td>
+        <td data-label="Tarifa">${fmt.format(tarifa)}</td>
+        <td data-label="Monto">${fmt.format(monto)}</td>
+        <td data-label="Estado"><span class="badge ${badgeClass}">${status}</span></td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
+      </tr>`;
       if (!monto) grupos.pendientes.push(row);
       else if (monto < tarifa) grupos.parciales.push(row);
       else grupos.pagados.push(row);
     });
-    const renderGrupo = (titulo, rows) => rows.length ? `<h2 class="h2 mt-4">${titulo}</h2><table>${rows.join('')}</table>` : '';
+    const renderGrupo = (titulo, rows) => rows.length ? `<h2 class="h2 mt-4">${titulo}</h2><table class="responsive-table"><thead><tr><th>Partido</th><th>Tarifa</th><th>Monto</th><th>Estado</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody>${rows.join('')}</tbody></table>` : '';
     const html = renderGrupo('Pendientes', grupos.pendientes) +
                  renderGrupo('Pagados Parcialmente', grupos.parciales) +
                  renderGrupo('Pagados', grupos.pagados);

--- a/src/features/delegaciones.js
+++ b/src/features/delegaciones.js
@@ -8,11 +8,12 @@ import { attachRowActions, renderActions } from '../ui/row-actions.js';
 
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
-  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Delegaciones</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table id="list"></table></div>`;
+  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Delegaciones</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table></div>`;
   const q = query(collection(db, paths.delegaciones()), where('ligaId','==',LIGA_ID), orderBy('nombre'));
   const unsub = onSnapshot(q, snap => {
-    const rows = snap.docs.map(d => `<tr><td>${d.data().nombre}</td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`).join('');
-    document.getElementById('list').innerHTML = rows || '<tr><td>No hay delegaciones</td></tr>';
+    const rows = snap.docs.map(d => `<tr><td data-label="Nombre">${d.data().nombre}</td>${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}</tr>`).join('');
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?2:1}">No hay delegaciones</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
   });
   pushCleanup(() => unsub());
   if (isAdmin) {

--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -8,7 +8,7 @@ import { attachRowActions, renderActions } from '../ui/row-actions.js';
 
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
-  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Equipos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table id="list"></table></div>`;
+  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Equipos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th><th>Rama</th><th>Categoría</th><th>Delegación</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table></div>`;
   const delSnap = await getDocs(query(collection(db, paths.delegaciones()), where('ligaId','==',LIGA_ID), orderBy('nombre')));
   const delegMap = {};
   delSnap.forEach(d => { delegMap[d.id] = d.data().nombre; });
@@ -16,9 +16,16 @@ export async function render(el) {
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => {
       const data = d.data();
-      return `<tr><td>${data.nombre}</td><td>${data.rama||''}</td><td>${data.categoria||''}</td><td>${delegMap[data.delegacionId]||''}</td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`;
+      return `<tr>
+        <td data-label="Nombre">${data.nombre}</td>
+        <td data-label="Rama">${data.rama||''}</td>
+        <td data-label="Categoría">${data.categoria||''}</td>
+        <td data-label="Delegación">${delegMap[data.delegacionId]||''}</td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
+      </tr>`;
     }).join('');
-    document.getElementById('list').innerHTML = rows || '<tr><td>No hay equipos</td></tr>';
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?5:4}">No hay equipos</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
   });
   pushCleanup(() => unsub());
   if (isAdmin) {

--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -18,7 +18,7 @@ export async function render(el) {
         <input id="buscar" class="input" placeholder="Buscar">
         <button id="limpiar" class="btn btn-secondary">Limpiar</button>
       </div>
-      <table id="list"></table>
+      <table class="responsive-table"><thead><tr><th>Fecha</th><th>Partido</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
     </div>
     ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo partido"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   const eqSnap = await getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID)));
@@ -33,9 +33,14 @@ export async function render(el) {
       const visita = equipos[data.visitaId] || data.visitaId;
       const marcador = data.jugado && data.marcadorLocal != null && data.marcadorVisita != null ?
         ` (${data.marcadorLocal}-${data.marcadorVisita})` : '';
-      return `<tr><td>${fecha}</td><td>${local} vs ${visita}${marcador}</td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`;
+      return `<tr>
+        <td data-label="Fecha">${fecha}</td>
+        <td data-label="Partido">${local} vs ${visita}${marcador}</td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
+      </tr>`;
     }).join('');
-    document.getElementById('list').innerHTML = rows || '<tr><td>No hay partidos</td></tr>';
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?3:2}">No hay partidos</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
   });
   pushCleanup(() => unsub());
   if (isAdmin) {

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -18,7 +18,7 @@ export async function render(el) {
         <input id="buscar" class="input" placeholder="Buscar">
         <button id="limpiar" class="btn btn-secondary">Limpiar</button>
       </div>
-      <table id="list"></table>
+      <table class="responsive-table"><thead><tr><th>Rama</th><th>Categoría</th><th>Tarifa</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
     </div>
     ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nueva tarifa"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   const q = query(collection(db, paths.tarifas()), where('ligaId','==',LIGA_ID), orderBy('rama'), orderBy('categoria'));
@@ -26,9 +26,15 @@ export async function render(el) {
     const rows = snap.docs.map(d => {
       const data = d.data();
       const monto = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0}).format(data.tarifa);
-      return `<tr><td>${data.rama}</td><td>${data.categoria}</td><td>${monto}</td>${isAdmin?'<td>'+renderActions(d.id)+'</td>':''}</tr>`;
+      return `<tr>
+        <td data-label="Rama">${data.rama}</td>
+        <td data-label="Categoría">${data.categoria}</td>
+        <td data-label="Tarifa">${monto}</td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
+      </tr>`;
     }).join('');
-    document.getElementById('list').innerHTML = rows || '<tr><td>No hay tarifas</td></tr>';
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?4:3}">No hay tarifas</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
   });
   pushCleanup(() => unsub());
   if (isAdmin) {

--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -155,3 +155,45 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
 /* Utility */
 .mt-4 { margin-top: var(--space-4); }
 
+/* Responsive table */
+.responsive-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.responsive-table th,
+.responsive-table td {
+  padding: var(--space-2);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+@media (max-width: 767px) {
+  .responsive-table thead {
+    display: none;
+  }
+  .responsive-table,
+  .responsive-table tbody,
+  .responsive-table tr,
+  .responsive-table td {
+    display: block;
+    width: 100%;
+  }
+  .responsive-table tr {
+    margin-bottom: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-3);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-1);
+  }
+  .responsive-table td {
+    border: none;
+    display: flex;
+    justify-content: space-between;
+    padding: var(--space-1) 0;
+  }
+  .responsive-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    margin-right: var(--space-3);
+  }
+}


### PR DESCRIPTION
## Summary
- style new responsive-table to show cards on small screens
- render tables with headers across arbitros, delegaciones, equipos, partidos, cobros, tarifas
- tag each cell with data-label for mobile card formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3a6ad57083258b5d43ae8851d766