### PR TITLE
fix: prevent card overflow on mobile

### DIFF
--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -18,6 +18,10 @@ body {
   font-family: var(--font-family-base);
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 [hidden] { display:none !important; }
 
 #app {


### PR DESCRIPTION
## Summary
- apply global `box-sizing: border-box` to keep card padding inside width and stop right-side overflow on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af40338a0c83259a7f5cd3507b079a