### PR TITLE
feat: enable multi-tournament management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Berumen Sports
 
-SPA simple para administrar liga Berumen usando Firebase y GitHub Pages.
+SPA simple para administrar torneos de Berumen Sports usando Firebase y GitHub Pages.
 
 ## Configuración
 1. Crea un proyecto Firebase y habilita Email/Password en Auth.
 2. Configura Firestore y copia las reglas de `firestore.rules` e índices de `firestore.indexes.json`.
 3. Edita `src/data/firebase.js` con tu `firebaseConfig` (usa storageBucket `<project-id>.appspot.com`).
 4. Despliega el repositorio en GitHub Pages (asegúrate de que `index.html` y la carpeta `assets/` estén en la raíz).
-5. Crea el primer usuario en Auth y agrega documento `users/{uid}` con `{ role: "admin", ligaId: "BERUMEN" }`.
+5. Crea el primer usuario en Auth y agrega documento `users/{uid}` con `{ role: "admin" }`.
 
 ## Desarrollo
 ```
@@ -22,4 +22,4 @@ npm test
 ## Uso
 - Login con correo/contraseña.
 - Dashboard con botón de prueba de escritura.
-- Módulos de equipos, árbitros, partidos, cobros y reportes básicos.
+- Módulos de torneos, equipos, árbitros, partidos, cobros y reportes básicos.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -4,7 +4,7 @@
       "collectionGroup": "equipos",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"torneoId","order":"ASCENDING"},
         {"fieldPath":"delegacionId","order":"ASCENDING"},
         {"fieldPath":"rama","order":"ASCENDING"},
         {"fieldPath":"categoria","order":"ASCENDING"},
@@ -15,7 +15,6 @@
       "collectionGroup": "arbitros",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
         {"fieldPath":"activo","order":"ASCENDING"},
         {"fieldPath":"nombre","order":"ASCENDING"}
       ]
@@ -24,7 +23,7 @@
       "collectionGroup": "partidos",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"torneoId","order":"ASCENDING"},
         {"fieldPath":"tempId","order":"ASCENDING"},
         {"fieldPath":"estado","order":"ASCENDING"},
         {"fieldPath":"fecha","order":"DESCENDING"}
@@ -34,7 +33,7 @@
       "collectionGroup": "cobros",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"torneoId","order":"ASCENDING"},
         {"fieldPath":"tempId","order":"ASCENDING"},
         {"fieldPath":"pagado","order":"ASCENDING"},
         {"fieldPath":"fechaCobro","order":"DESCENDING"}
@@ -44,7 +43,7 @@
       "collectionGroup": "delegaciones",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"torneoId","order":"ASCENDING"},
         {"fieldPath":"nombre","order":"ASCENDING"}
       ]
     },
@@ -52,7 +51,7 @@
       "collectionGroup": "tarifas",
       "queryScope": "COLLECTION",
       "fields": [
-        {"fieldPath":"ligaId","order":"ASCENDING"},
+        {"fieldPath":"torneoId","order":"ASCENDING"},
         {"fieldPath":"rama","order":"ASCENDING"},
         {"fieldPath":"categoria","order":"ASCENDING"}
       ]

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,7 @@ service cloud.firestore {
         exists(/databases/$(db)/documents/users/$(request.auth.uid)) &&
         get(/databases/$(db)/documents/users/$(request.auth.uid)).data.role == "admin";
     }
-    function isLiga(doc) { return doc.ligaId == "BERUMEN"; }
+    function isTorneo(doc) { return !('torneoId' in doc) || (doc.torneoId is string && doc.torneoId.size() > 0); }
     function isTemp(doc) { return !('tempId' in doc) || doc.tempId == "2025"; }
 
     match /users/{uid} {
@@ -17,16 +17,16 @@ service cloud.firestore {
 
     // Allow all authenticated users to create diagnostic entries
     match /diagnostics/{id} {
-      allow read: if signedIn() && isLiga(resource.data) && isTemp(resource.data);
-      allow create: if signedIn() && isLiga(request.resource.data) && isTemp(request.resource.data);
+      allow read: if signedIn() && isTorneo(resource.data) && isTemp(resource.data);
+      allow create: if signedIn() && isTorneo(request.resource.data) && isTemp(request.resource.data);
       // Only admins can modify or delete diagnostics
-      allow update, delete: if signedIn() && isAdmin() && isLiga(resource.data) && isTemp(resource.data);
+      allow update, delete: if signedIn() && isAdmin() && isTorneo(resource.data) && isTemp(resource.data);
     }
 
     match /{coll}/{id} {
-      allow read: if signedIn() && isLiga(resource.data) && isTemp(resource.data);
-      allow create: if signedIn() && isAdmin() && isLiga(request.resource.data) && isTemp(request.resource.data);
-      allow update, delete: if signedIn() && isAdmin() && isLiga(resource.data) && isTemp(resource.data);
+      allow read: if signedIn() && isTorneo(resource.data) && isTemp(resource.data);
+      allow create: if signedIn() && isAdmin() && isTorneo(request.resource.data) && isTemp(request.resource.data);
+      allow update, delete: if signedIn() && isAdmin() && isTorneo(resource.data) && isTemp(resource.data);
     }
   }
 }

--- a/src/core/auth.js
+++ b/src/core/auth.js
@@ -8,8 +8,6 @@ import {
   getDoc,
   setDoc,
 } from '../data/firebase.js';
-
-const LIGA_ID = 'BERUMEN';
 let cachedRole = null;
 let cachedName = null;
 
@@ -25,7 +23,7 @@ export async function fetchUserInfo(uid) {
   try {
     const snap = await getDoc(ref);
     if (!snap.exists()) {
-      await setDoc(ref, { role: 'consulta', ligaId: LIGA_ID });
+      await setDoc(ref, { role: 'consulta' });
       cachedRole = 'consulta';
       cachedName = '';
     } else {

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -1,8 +1,11 @@
+import { onTorneoChange } from '../data/torneos.js';
+
 const routes = {
   '/': () => import('../features/home.js'),
   '/equipos': () => import('../features/equipos.js'),
   '/delegaciones': () => import('../features/delegaciones.js'),
   '/arbitros': () => import('../features/arbitros.js'),
+  '/torneos': () => import('../features/torneos.js'),
   '/partidos': () => import('../features/partidos.js'),
   '/cobros': () => import('../features/cobros.js'),
   '/tarifas': () => import('../features/tarifas.js'),
@@ -36,5 +39,6 @@ export function initRouter() {
   if (bound) return;
   bound = true;
   window.addEventListener('hashchange', () => requestAnimationFrame(loadRoute));
+  onTorneoChange(() => requestAnimationFrame(loadRoute));
   requestAnimationFrame(loadRoute);
 }

--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -1,9 +1,12 @@
+import { watchTorneos, getActiveTorneo, setActiveTorneo, onTorneoChange } from '../data/torneos.js';
+
 const shellHtml = `
 <header class="topbar">
   <button id="menu-btn" class="icon-btn" aria-label="Abrir menú">
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#menu"></use></svg>
   </button>
   <div id="user-info" class="topbar-title">Berumen <span id="user-role" class="chip"></span></div>
+  <select id="torneo-switch" class="input"></select>
   <button id="logout-btn" class="icon-btn" onclick="appLogout()" aria-label="Configuración" hidden>
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#settings"></use></svg>
   </button>
@@ -14,6 +17,7 @@ const shellHtml = `
     <li><a href="#/equipos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#users"></use></svg><span>Equipos</span></a></li>
     <li><a href="#/delegaciones"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Delegaciones</span></a></li>
     <li><a href="#/arbitros"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Árbitros</span></a></li>
+    <li><a href="#/torneos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#chart"></use></svg><span>Torneos</span></a></li>
     <li><a href="#/partidos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#calendar"></use></svg><span>Partidos</span></a></li>
     <li><a href="#/cobros"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#currency"></use></svg><span>Cobros</span></a></li>
     <li><a href="#/tarifas"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#currency"></use></svg><span>Tarifas</span></a></li>
@@ -36,6 +40,14 @@ export function renderShell() {
   const menuBtn = document.getElementById('menu-btn');
   const drawer = document.getElementById('drawer');
   const overlay = document.getElementById('drawer-overlay');
+  const torneoSelect = document.getElementById('torneo-switch');
+  watchTorneos(list => {
+    torneoSelect.innerHTML = list.map(t => `<option value="${t.id}">${t.nombre}</option>`).join('');
+    if (!getActiveTorneo() && list.length) setActiveTorneo(list[0].id);
+    torneoSelect.value = getActiveTorneo() || '';
+  });
+  torneoSelect.addEventListener('change', e => setActiveTorneo(e.target.value));
+  onTorneoChange(id => { torneoSelect.value = id || ''; });
   function closeDrawer() {
     drawer.hidden = true;
     overlay.hidden = true;

--- a/src/data/paths.js
+++ b/src/data/paths.js
@@ -1,8 +1,8 @@
-export const LIGA_ID = 'BERUMEN';
 export const TEMP_ID = '2025';
 
 export const paths = {
   users: () => 'users',
+  torneos: () => 'torneos',
   delegaciones: () => 'delegaciones',
   equipos: () => 'equipos',
   arbitros: () => 'arbitros',

--- a/src/data/repo.js
+++ b/src/data/repo.js
@@ -1,5 +1,6 @@
 import { db, collection, addDoc, updateDoc, deleteDoc, doc } from './firebase.js';
-import { LIGA_ID, TEMP_ID, paths } from './paths.js';
+import { TEMP_ID, paths } from './paths.js';
+import { getActiveTorneo } from './torneos.js';
 
 async function safeWrite(cb, label) {
   try {
@@ -13,7 +14,7 @@ async function safeWrite(cb, label) {
 }
 
 export function addEquipo(data) {
-  return safeWrite(() => addDoc(collection(db, paths.equipos()), { ...data, ligaId: LIGA_ID }), 'addEquipo');
+  return safeWrite(() => addDoc(collection(db, paths.equipos()), { ...data, torneoId: getActiveTorneo() }), 'addEquipo');
 }
 export function updateEquipo(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.equipos(), id), data), 'updateEquipo');
@@ -22,7 +23,7 @@ export function deleteEquipo(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.equipos(), id)), 'deleteEquipo');
 }
 export function addDelegacion(data) {
-  return safeWrite(() => addDoc(collection(db, paths.delegaciones()), { ...data, ligaId: LIGA_ID }), 'addDelegacion');
+  return safeWrite(() => addDoc(collection(db, paths.delegaciones()), { ...data, torneoId: getActiveTorneo() }), 'addDelegacion');
 }
 export function updateDelegacion(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.delegaciones(), id), data), 'updateDelegacion');
@@ -31,7 +32,7 @@ export function deleteDelegacion(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.delegaciones(), id)), 'deleteDelegacion');
 }
 export function addArbitro(data) {
-  return safeWrite(() => addDoc(collection(db, paths.arbitros()), { ...data, ligaId: LIGA_ID }), 'addArbitro');
+  return safeWrite(() => addDoc(collection(db, paths.arbitros()), data), 'addArbitro');
 }
 export function updateArbitro(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.arbitros(), id), data), 'updateArbitro');
@@ -40,7 +41,7 @@ export function deleteArbitro(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.arbitros(), id)), 'deleteArbitro');
 }
 export function addPartido(data) {
-  return safeWrite(() => addDoc(collection(db, paths.partidos()), { ...data, ligaId: LIGA_ID, tempId: TEMP_ID }), 'addPartido');
+  return safeWrite(() => addDoc(collection(db, paths.partidos()), { ...data, torneoId: getActiveTorneo(), tempId: TEMP_ID }), 'addPartido');
 }
 export function updatePartido(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.partidos(), id), data), 'updatePartido');
@@ -49,7 +50,7 @@ export function deletePartido(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.partidos(), id)), 'deletePartido');
 }
 export function addCobro(data) {
-  return safeWrite(() => addDoc(collection(db, paths.cobros()), { ...data, ligaId: LIGA_ID, tempId: TEMP_ID }), 'addCobro');
+  return safeWrite(() => addDoc(collection(db, paths.cobros()), { ...data, torneoId: getActiveTorneo(), tempId: TEMP_ID }), 'addCobro');
 }
 export function updateCobro(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.cobros(), id), data), 'updateCobro');
@@ -58,7 +59,7 @@ export function deleteCobro(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.cobros(), id)), 'deleteCobro');
 }
 export function addTarifa(data) {
-  return safeWrite(() => addDoc(collection(db, paths.tarifas()), { ...data, ligaId: LIGA_ID }), 'addTarifa');
+  return safeWrite(() => addDoc(collection(db, paths.tarifas()), { ...data, torneoId: getActiveTorneo() }), 'addTarifa');
 }
 export function updateTarifa(id, data) {
   return safeWrite(() => updateDoc(doc(db, paths.tarifas(), id), data), 'updateTarifa');
@@ -67,5 +68,5 @@ export function deleteTarifa(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.tarifas(), id)), 'deleteTarifa');
 }
 export function addDiagnostic(note, byUid) {
-  return safeWrite(() => addDoc(collection(db, paths.diagnostics()), { note, byUid, createdAt: Date.now(), ligaId: LIGA_ID }), 'addDiagnostic');
+  return safeWrite(() => addDoc(collection(db, paths.diagnostics()), { note, byUid, createdAt: Date.now(), torneoId: getActiveTorneo() }), 'addDiagnostic');
 }

--- a/src/data/torneos.js
+++ b/src/data/torneos.js
@@ -1,0 +1,40 @@
+import { db, collection, query, onSnapshot, addDoc, updateDoc, deleteDoc, doc } from './firebase.js';
+import { paths } from './paths.js';
+
+const ACTIVE_KEY = 'torneoId';
+let activeTorneoId = localStorage.getItem(ACTIVE_KEY);
+
+export function getActiveTorneo() {
+  return activeTorneoId;
+}
+
+export function setActiveTorneo(id) {
+  activeTorneoId = id;
+  if (id) {
+    localStorage.setItem(ACTIVE_KEY, id);
+  }
+  document.dispatchEvent(new CustomEvent('torneo-changed', { detail: id }));
+}
+
+export function onTorneoChange(cb) {
+  document.addEventListener('torneo-changed', e => cb(e.detail));
+}
+
+export function watchTorneos(cb) {
+  return onSnapshot(query(collection(db, paths.torneos())), snap => {
+    const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    cb(list);
+  });
+}
+
+export function addTorneo(data) {
+  return addDoc(collection(db, paths.torneos()), data);
+}
+
+export function updateTorneo(id, data) {
+  return updateDoc(doc(db, paths.torneos(), id), data);
+}
+
+export function deleteTorneo(id) {
+  return deleteDoc(doc(db, paths.torneos(), id));
+}

--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -1,5 +1,5 @@
-import { db, collection, query, where, onSnapshot, orderBy, doc, getDoc } from '../data/firebase.js';
-import { paths, LIGA_ID } from '../data/paths.js';
+import { db, collection, query, onSnapshot, orderBy, doc, getDoc } from '../data/firebase.js';
+import { paths } from '../data/paths.js';
 import { addArbitro, updateArbitro, deleteArbitro } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
 import { pushCleanup } from '../core/router.js';
@@ -21,7 +21,7 @@ export async function render(el) {
       <table class="responsive-table"><thead><tr><th>Nombre</th><th>Teléfono</th><th>Email</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
     </div>
     ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo árbitro"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
-  const q = query(collection(db, paths.arbitros()), where('ligaId','==',LIGA_ID), orderBy('nombre'));
+  const q = query(collection(db, paths.arbitros()), orderBy('nombre'));
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => {
       const data = d.data();

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -1,5 +1,6 @@
 import { db, collection, query, where, onSnapshot, orderBy, getDocs, doc, getDoc } from '../data/firebase.js';
-import { paths, LIGA_ID, TEMP_ID } from '../data/paths.js';
+import { paths, TEMP_ID } from '../data/paths.js';
+import { getActiveTorneo } from '../data/torneos.js';
 import { addCobro, updateCobro, deleteCobro } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
 import { pushCleanup } from '../core/router.js';
@@ -24,10 +25,10 @@ export async function render(el) {
   const fmt = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0});
 
   const [eqSnap, paSnap] = await Promise.all([
-    getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID))),
+    getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()))),
     getDocs(query(
       collection(db, paths.partidos()),
-      where('ligaId','==',LIGA_ID),
+      where('torneoId','==',getActiveTorneo()),
       where('tempId','==',TEMP_ID)
     ))
   ]);
@@ -36,7 +37,7 @@ export async function render(el) {
 
   const q = query(
     collection(db, paths.cobros()),
-    where('ligaId','==',LIGA_ID),
+    where('torneoId','==',getActiveTorneo()),
     where('tempId','==',TEMP_ID),
     orderBy('fechaCobro','desc')
   );
@@ -91,13 +92,13 @@ async function openCobro(id) {
   const [paSnap, taSnap, coSnap, eqSnap] = await Promise.all([
     getDocs(query(
       collection(db, paths.partidos()),
-      where('ligaId','==',LIGA_ID),
+      where('torneoId','==',getActiveTorneo()),
       where('tempId','==',TEMP_ID),
       orderBy('fecha','desc')
     )),
-    getDocs(query(collection(db, paths.tarifas()), where('ligaId','==',LIGA_ID))),
+    getDocs(query(collection(db, paths.tarifas()), where('torneoId','==',getActiveTorneo()))),
     isEdit ? getDoc(doc(db, paths.cobros(), id)) : Promise.resolve(null),
-    getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID)))
+    getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo())))
   ]);
   const partidos = paSnap.docs.map(d => ({ id: d.id, ...d.data() }));
   const tarifas = taSnap.docs.map(d => d.data());

--- a/src/features/delegaciones.js
+++ b/src/features/delegaciones.js
@@ -1,5 +1,6 @@
 import { db, collection, query, where, onSnapshot, orderBy, doc, getDoc } from '../data/firebase.js';
-import { paths, LIGA_ID } from '../data/paths.js';
+import { paths } from '../data/paths.js';
+import { getActiveTorneo } from '../data/torneos.js';
 import { addDelegacion, updateDelegacion, deleteDelegacion } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
 import { pushCleanup } from '../core/router.js';
@@ -9,7 +10,7 @@ import { attachRowActions, renderActions } from '../ui/row-actions.js';
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
   el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Delegaciones</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table></div>`;
-  const q = query(collection(db, paths.delegaciones()), where('ligaId','==',LIGA_ID), orderBy('nombre'));
+  const q = query(collection(db, paths.delegaciones()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'));
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => `<tr><td data-label="Nombre">${d.data().nombre}</td>${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}</tr>`).join('');
     const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?2:1}">No hay delegaciones</td></tr>`;

--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -1,5 +1,6 @@
 import { db, collection, query, where, onSnapshot, orderBy, getDocs, doc, getDoc } from '../data/firebase.js';
-import { paths, LIGA_ID } from '../data/paths.js';
+import { paths } from '../data/paths.js';
+import { getActiveTorneo } from '../data/torneos.js';
 import { addEquipo, updateEquipo, deleteEquipo } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
 import { pushCleanup } from '../core/router.js';
@@ -9,10 +10,10 @@ import { attachRowActions, renderActions } from '../ui/row-actions.js';
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
   el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Equipos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th><th>Rama</th><th>Categoría</th><th>Delegación</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table></div>`;
-  const delSnap = await getDocs(query(collection(db, paths.delegaciones()), where('ligaId','==',LIGA_ID), orderBy('nombre')));
+  const delSnap = await getDocs(query(collection(db, paths.delegaciones()), where('torneoId','==',getActiveTorneo()), orderBy('nombre')));
   const delegMap = {};
   delSnap.forEach(d => { delegMap[d.id] = d.data().nombre; });
-  const q = query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID), orderBy('nombre'));
+  const q = query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'));
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => {
       const data = d.data();

--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -1,5 +1,6 @@
 import { db, collection, query, where, getDocs } from '../data/firebase.js';
-import { paths, LIGA_ID, TEMP_ID } from '../data/paths.js';
+import { paths, TEMP_ID } from '../data/paths.js';
+import { getActiveTorneo } from '../data/torneos.js';
 
 export async function render(el) {
   const chartJs = await import('https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js');
@@ -73,18 +74,18 @@ export async function render(el) {
     const { start, end } = getRange(period, dateStr);
 
     const [delegSnap, equipoSnap, partidoSnap, cobroSnap] = await Promise.all([
-      getDocs(query(collection(db, paths.delegaciones()), where('ligaId', '==', LIGA_ID))),
-      getDocs(query(collection(db, paths.equipos()), where('ligaId', '==', LIGA_ID))),
+      getDocs(query(collection(db, paths.delegaciones()), where('torneoId', '==', getActiveTorneo()))),
+      getDocs(query(collection(db, paths.equipos()), where('torneoId', '==', getActiveTorneo()))),
       getDocs(query(
         collection(db, paths.partidos()),
-        where('ligaId', '==', LIGA_ID),
+        where('torneoId', '==', getActiveTorneo()),
         where('tempId', '==', TEMP_ID),
         where('fecha', '>=', start),
         where('fecha', '<', end)
       )),
       getDocs(query(
         collection(db, paths.cobros()),
-        where('ligaId', '==', LIGA_ID),
+        where('torneoId', '==', getActiveTorneo()),
         where('tempId', '==', TEMP_ID),
         where('fechaCobro', '>=', start),
         where('fechaCobro', '<', end)

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -1,5 +1,6 @@
 import { db, collection, query, where, onSnapshot, orderBy, getDocs, doc, getDoc } from '../data/firebase.js';
-import { paths, LIGA_ID } from '../data/paths.js';
+import { paths } from '../data/paths.js';
+import { getActiveTorneo } from '../data/torneos.js';
 import { addTarifa, updateTarifa, deleteTarifa } from '../data/repo.js';
 import { openModal, closeModal } from '../core/modal-manager.js';
 import { pushCleanup } from '../core/router.js';
@@ -21,7 +22,7 @@ export async function render(el) {
       <table class="responsive-table"><thead><tr><th>Rama</th><th>Categoría</th><th>Tarifa</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
     </div>
     ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nueva tarifa"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
-  const q = query(collection(db, paths.tarifas()), where('ligaId','==',LIGA_ID), orderBy('rama'), orderBy('categoria'));
+  const q = query(collection(db, paths.tarifas()), where('torneoId','==',getActiveTorneo()), orderBy('rama'), orderBy('categoria'));
   const unsub = onSnapshot(q, snap => {
     const rows = snap.docs.map(d => {
       const data = d.data();
@@ -48,7 +49,7 @@ export async function render(el) {
 async function openTarifa(id) {
   const isEdit = !!id;
   const [eqSnap, taSnap] = await Promise.all([
-    getDocs(query(collection(db, paths.equipos()), where('ligaId','==',LIGA_ID))),
+    getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()))),
     isEdit ? getDoc(doc(db, paths.tarifas(), id)) : Promise.resolve(null)
   ]);
   const equipos = eqSnap.docs.map(d => d.data());

--- a/src/features/torneos.js
+++ b/src/features/torneos.js
@@ -1,0 +1,41 @@
+import { db, doc, getDoc } from '../data/firebase.js';
+import { paths } from '../data/paths.js';
+import { watchTorneos, addTorneo, updateTorneo, deleteTorneo, setActiveTorneo, getActiveTorneo } from '../data/torneos.js';
+import { openModal, closeModal } from '../core/modal-manager.js';
+import { pushCleanup } from '../core/router.js';
+import { getUserRole } from '../core/auth.js';
+import { attachRowActions, renderActions } from '../ui/row-actions.js';
+
+export async function render(el) {
+  const isAdmin = getUserRole() === 'admin';
+  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Torneos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th><th>Activo</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table></div>`;
+  const unsub = watchTorneos(list => {
+    const rows = list.map(t => `<tr><td data-label="Nombre">${t.nombre}</td><td data-label="Activo"><input type="radio" name="activo" value="${t.id}" ${t.id===getActiveTorneo()?'checked':''}></td>${isAdmin?`<td data-label="Acciones">${renderActions(t.id)}</td>`:''}</tr>`).join('');
+    const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?3:2}">No hay torneos</td></tr>`;
+    document.getElementById('list').innerHTML = rows || empty;
+    document.querySelectorAll('input[name="activo"]').forEach(r => r.addEventListener('change', e => setActiveTorneo(e.target.value)));
+  });
+  pushCleanup(() => unsub());
+  if (isAdmin) {
+    document.getElementById('nuevo').addEventListener('click', () => openTorneo());
+    attachRowActions(document.getElementById('list'), { onEdit:id=>openTorneo(id), onDelete:id=>deleteTorneo(id) }, true);
+  }
+}
+
+async function openTorneo(id) {
+  const isEdit = !!id;
+  let existing = { nombre: '' };
+  if (isEdit) {
+    const snap = await getDoc(doc(db, paths.torneos(), id));
+    if (snap.exists()) existing = snap.data();
+  }
+  openModal(`<form id="to-form" class="modal-form"><label class="field"><span class="label">Nombre</span><input class="input" name="nombre" placeholder="Nombre"></label><div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="closeModal()">Cancelar</button><button class="btn btn-primary">Guardar</button></div></form>`);
+  const form = document.getElementById('to-form');
+  form.nombre.value = existing.nombre || '';
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = { nombre: form.nombre.value };
+    if (isEdit) await updateTorneo(id, data); else await addTorneo(data);
+    closeModal();
+  });
+}


### PR DESCRIPTION
## Summary
- add tournament store and selector in header
- replace fixed league references with dynamic tournament filtering
- introduce torneos module for CRUD and switching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4c1a67a8832589e01978e6bc84d6