### PR TITLE
Reordena menú y actualiza tabbar

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -14,22 +14,22 @@ const shellHtml = `
 <nav id="drawer" class="drawer" hidden>
   <ul>
     <li><a href="#/"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#home"></use></svg><span>Home</span></a></li>
-    <li><a href="#/equipos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#users"></use></svg><span>Equipos</span></a></li>
-    <li><a href="#/delegaciones"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Delegaciones</span></a></li>
-    <li><a href="#/arbitros"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Árbitros</span></a></li>
     <li><a href="#/torneos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#chart"></use></svg><span>Torneos</span></a></li>
+    <li><a href="#/delegaciones"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Delegaciones</span></a></li>
+    <li><a href="#/equipos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#users"></use></svg><span>Equipos</span></a></li>
     <li><a href="#/partidos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#calendar"></use></svg><span>Partidos</span></a></li>
     <li><a href="#/cobros"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#currency"></use></svg><span>Cobros</span></a></li>
     <li><a href="#/tarifas"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#currency"></use></svg><span>Tarifas</span></a></li>
+    <li><a href="#/arbitros"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Árbitros</span></a></li>
     <li><a href="#/reportes"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#chart"></use></svg><span>Reportes</span></a></li>
   </ul>
 </nav>
 <div id="drawer-overlay" class="drawer-overlay" hidden></div>
 <nav class="tabbar" role="navigation">
-  <a href="#/" class="tabbar-item"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#home"></use></svg><span>Home</span></a>
   <a href="#/equipos" class="tabbar-item"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#users"></use></svg><span>Equipos</span></a>
   <a href="#/partidos" class="tabbar-item"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#calendar"></use></svg><span>Partidos</span></a>
   <a href="#/cobros" class="tabbar-item"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#currency"></use></svg><span>Cobros</span></a>
+  <a href="#/reportes" class="tabbar-item"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#chart"></use></svg><span>Reportes</span></a>
 </nav>
 <div id="modal-root"></div>`;
 


### PR DESCRIPTION
## Summary
- Reordena el menú principal para priorizar torneos y delegaciones
- Reduce la tabbar a cuatro secciones: Equipos, Partidos, Cobros y Reportes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af528d85208325a4ab7a14f2175707