### PR TITLE
Fix tarifa not loading when editing cobro modal

### DIFF
--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -141,8 +141,10 @@ async function openCobro(id, partidoId) {
   form.partido.addEventListener('change', updateTarifa);
   form.partido.value = existing.partidoId || partidoId || '';
   updateTarifa();
-  form.tarifa.value = fmt.format(existing.tarifa || 0);
-  form.tarifa.dataset.raw = existing.tarifa || 0;
+  if (existing.tarifa) {
+    form.tarifa.value = fmt.format(existing.tarifa);
+    form.tarifa.dataset.raw = existing.tarifa;
+  }
   form.monto.value = existing.monto || '';
   form.addEventListener('submit', async e => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Ensure tarifa field displays existing value when editing cobros

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5859ac4c8325945863bf0c8810c4