### PR TITLE
Rediseñar topbar móvil y mejorar área del menú

### DIFF
--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -54,9 +54,10 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
   border:none;
   padding: var(--space-2);
   border-radius: var(--radius-md);
-  width:44px; height:44px;
+  width:48px; height:48px;
   display:inline-flex; align-items:center; justify-content:center;
   color:inherit;
+  touch-action: manipulation;
 }
 .icon-btn:hover { background: var(--color-surface-elevated); }
 

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -1,5 +1,6 @@
+/* Layout tokens */
 :root {
-  --topbar-h: 56px;
+  --topbar-h: 100px;
   --tabbar-h: 60px;
 }
 
@@ -44,6 +45,24 @@ body {
   justify-content: space-between;
   padding: 0 var(--space-4);
   z-index: 1000;
+  flex-wrap: wrap;
+}
+
+#torneo-switch {
+  flex: 0 0 100%;
+  width: 100%;
+  margin-top: var(--space-2);
+}
+
+@media (min-width:1024px) {
+  .topbar {
+    flex-wrap: nowrap;
+  }
+  #torneo-switch {
+    flex: 0 0 auto;
+    width: auto;
+    margin-top: 0;
+  }
 }
 
 .topbar-title {


### PR DESCRIPTION
## Summary
- Rediseña la topbar en móviles para mostrar el usuario arriba y el selector de torneo debajo
- Amplía el área táctil del botón de menú para mejorar clics en iPad/iPhone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5f558bfc832583850e51529dd1dd