### PR TITLE
Fix mobile topbar layout

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -6,10 +6,10 @@ const shellHtml = `
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#menu"></use></svg>
   </button>
   <div id="user-info" class="topbar-title">Berumen <span id="user-role" class="chip"></span></div>
-  <select id="torneo-switch" class="input"></select>
   <button id="logout-btn" class="icon-btn" onclick="appLogout()" aria-label="Configuración" hidden>
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#settings"></use></svg>
   </button>
+  <select id="torneo-switch" class="input"></select>
 </header>
 <nav id="drawer" class="drawer" hidden>
   <ul>

--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -141,7 +141,7 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
 .modal-footer { display:flex; justify-content:flex-end; gap:var(--space-3); margin-top:var(--space-4); }
 .modal-form { display:flex; flex-direction:column; gap:var(--space-4); }
 
-@media (min-width:1024px) {
+@media (min-width:1025px) {
   .modal-sheet {
     max-width:60vw;
     left:50%;

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -4,7 +4,7 @@
   --tabbar-h: 60px;
 }
 
-@media (min-width:1024px) {
+@media (min-width:1025px) {
   :root { --topbar-h: 64px; }
 }
 
@@ -41,7 +41,7 @@ body {
   background: var(--color-surface);
   box-shadow: var(--shadow-1);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: 0 var(--space-4);
   z-index: 1000;
@@ -54,14 +54,19 @@ body {
   margin-top: var(--space-2);
 }
 
-@media (min-width:1024px) {
+@media (min-width:1025px) {
   .topbar {
     flex-wrap: nowrap;
+    align-items: center;
   }
   #torneo-switch {
     flex: 0 0 auto;
     width: auto;
     margin-top: 0;
+    order: 2;
+  }
+  #logout-btn {
+    order: 3;
   }
 }
 
@@ -118,7 +123,7 @@ body {
   padding-bottom: env(safe-area-inset-bottom);
   z-index: 900;
 }
-@media (min-width:1024px) {
+@media (min-width:1025px) {
   .tabbar { display: none; }
 }
 .tabbar-item { display:flex; flex-direction:column; align-items:center; gap:var(--space-1); text-decoration:none; color:var(--color-text-muted); }


### PR DESCRIPTION
## Summary
- Keep logout button on first row and move tournament selector to second row on mobile
- Adjust topbar styles for two-line mobile layout and shift desktop breakpoint to 1025px
- Sync component modal breakpoint with new desktop threshold

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af6671d3c48325813b60eb272142ab