### PR TITLE
fix blank PDF export

### DIFF
--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -196,8 +196,11 @@ export async function render(el) {
     breakEl.className = 'html2pdf__page-break';
     exportEl.appendChild(breakEl);
     exportEl.appendChild(document.getElementById('tabla').cloneNode(true));
-    exportEl.style.position = 'absolute';
-    exportEl.style.left = '-9999px';
+    exportEl.style.position = 'fixed';
+    exportEl.style.top = '0';
+    exportEl.style.left = '0';
+    exportEl.style.width = '100%';
+    exportEl.style.visibility = 'hidden';
     document.body.appendChild(exportEl);
     const opt = {
       margin: 0.25,


### PR DESCRIPTION
## Summary
- ensure exported report element remains in viewport and hidden so html2pdf captures content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa4460b6c8325b1a7707329b8f1ec