### PR TITLE
Fix blank PDF export

### DIFF
--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -200,7 +200,10 @@ export async function render(el) {
     exportEl.style.top = '0';
     exportEl.style.left = '0';
     exportEl.style.width = '100%';
-    exportEl.style.visibility = 'hidden';
+    // Use opacity instead of visibility so html2canvas renders the content
+    // but keep it out of view for the user
+    exportEl.style.opacity = '0';
+    exportEl.style.pointerEvents = 'none';
     document.body.appendChild(exportEl);
     const opt = {
       margin: 0.25,


### PR DESCRIPTION
## Summary
- Ensure PDF export content is rendered by hiding with opacity instead of visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa572db4c8325a7a05008e4d97081