### PR TITLE
fix: ensure PDF content renders

### DIFF
--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -205,6 +205,8 @@ export async function render(el) {
     exportEl.style.opacity = '0';
     exportEl.style.pointerEvents = 'none';
     document.body.appendChild(exportEl);
+    // Ensure the element is rendered before capturing it
+    await new Promise(resolve => requestAnimationFrame(resolve));
     const opt = {
       margin: 0.25,
       filename: 'reporte.pdf',


### PR DESCRIPTION
## Summary
- Wait for hidden export container to render before generating PDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb020ca988325bf20a335c7a3fb9c