### PR TITLE
Corrige encabezado faltante en reportes PDF

### DIFF
--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -58,9 +58,9 @@ export async function render(el) {
     const hora = now.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'Árbitros', style: 'title' },
           { text: `${ligaNombre} - ${fecha} ${hora}`, style: 'small' }

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -135,9 +135,9 @@ export async function render(el) {
     const hora = now.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'Cobros', style: 'title' },
           { text: `${ligaNombre} - ${fecha} ${hora}`, style: 'small' }

--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -57,9 +57,9 @@ export async function render(el) {
     const hora = now.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'Equipos', style: 'title' },
           { text: `${ligaNombre} - ${fecha} ${hora}`, style: 'small' }

--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -88,9 +88,9 @@ export async function render(el) {
     const hora = now.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'Partidos', style: 'title' },
           { text: `${ligaNombre} - ${fecha} ${hora}`, style: 'small' }

--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -243,9 +243,9 @@ export async function render(el) {
     const fecha = now.toLocaleDateString('es-MX', { year: 'numeric', month: '2-digit', day: '2-digit' });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'BERUMEN SPORTS', style: 'title', alignment: 'center' },
           { text: `Torneo: ${ligaNombre}    Fecha del reporte: ${fecha}`, style: 'small', alignment: 'center' }

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -60,9 +60,9 @@ export async function render(el) {
     const hora = now.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit', hour12: false });
     const docDefinition = {
       pageSize: 'A4',
-      pageMargins: [20, 24, 20, 28],
+      pageMargins: [20, 60, 20, 28],
       header: {
-        margin: [20, 10, 20, 0],
+        margin: [20, 20, 20, 0],
         stack: [
           { text: 'Tarifas', style: 'title' },
           { text: `${ligaNombre} - ${fecha} ${hora}`, style: 'small' }


### PR DESCRIPTION
## Resumen
- Ajusta márgenes superiores en las definiciones de PDF para evitar que el contenido tape el encabezado.
- Establece un margen interno mayor en los encabezados de los reportes.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afbc4961b48325ade56ee00258066b