### PR TITLE
feat: add filters to main sections

### DIFF
--- a/src/features/equipos.js
+++ b/src/features/equipos.js
@@ -10,38 +10,77 @@ import { exportToPdf } from '../pdf/export.js';
 
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
-  el.innerHTML = `<div class="card"><div class="page-header"><h1 class="h1">Equipos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}</div><table class="responsive-table"><thead><tr><th>Nombre</th><th>Rama</th><th>Categoría</th><th>Delegación</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table><div class="toolbar"><button id="exportar-pdf" class="btn btn-secondary">Exportar PDF</button></div></div>`;
-  const [delSnap, toSnap] = await Promise.all([
+  const [delSnap, toSnap, eqSnap] = await Promise.all([
     getDocs(query(collection(db, paths.delegaciones()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'))),
-    getDoc(doc(db, paths.torneos(), getActiveTorneo()))
+    getDoc(doc(db, paths.torneos(), getActiveTorneo())),
+    getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()), orderBy('nombre')))
   ]);
   const delegMap = {};
   delSnap.forEach(d => { delegMap[d.id] = d.data().nombre; });
+  const equiposInit = eqSnap.docs.map(d => ({ id: d.id, ...d.data() }));
   const ligaNombre = toSnap.data()?.nombre || '';
+  const ramas = [...new Set(equiposInit.map(e => e.rama).filter(Boolean))];
+  const categorias = [...new Set(equiposInit.map(e => e.categoria).filter(Boolean))];
+  const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
+  const catOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+  const delegacionOpts = Object.entries(delegMap).map(([id,nombre]) => `<option value="${id}">${nombre}</option>`).join('');
+  el.innerHTML = `
+    <div class="card">
+      <div class="page-header">
+        <h1 class="h1">Equipos</h1>${isAdmin?'<button id="nuevo" class="btn btn-primary">Nuevo</button>':''}
+      </div>
+      <div class="toolbar">
+        <select id="f-rama" class="input"><option value="">Rama</option>${ramaOpts}</select>
+        <select id="f-categoria" class="input"><option value="">Categoría</option>${catOpts}</select>
+        <select id="f-delegacion" class="input"><option value="">Delegación</option>${delegacionOpts}</select>
+        <button id="aplicar" class="btn btn-secondary">Aplicar</button>
+        <button id="limpiar" class="btn btn-secondary">Limpiar</button>
+      </div>
+      <table class="responsive-table"><thead><tr><th>Nombre</th><th>Rama</th><th>Categoría</th><th>Delegación</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
+      <div class="toolbar"><button id="exportar-pdf" class="btn btn-secondary">Exportar PDF</button></div>
+    </div>`;
+  let equiposData = equiposInit;
   let exportRows = [];
-  const q = query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'));
-  const unsub = onSnapshot(q, snap => {
-    exportRows = [];
-    const rows = snap.docs.map(d => {
-      const data = d.data();
-      exportRows.push({
-        nombre: data.nombre,
-        rama: data.rama || '',
-        categoria: data.categoria || '',
-        delegacion: delegMap[data.delegacionId] || ''
-      });
-      return `<tr>
-        <td data-label="Nombre">${data.nombre}</td>
-        <td data-label="Rama">${data.rama||''}</td>
-        <td data-label="Categoría">${data.categoria||''}</td>
-        <td data-label="Delegación">${delegMap[data.delegacionId]||''}</td>
-        ${isAdmin?`<td data-label="Acciones">${renderActions(d.id)}</td>`:''}
-      </tr>`;
-    }).join('');
+  function update() {
+    const rFilter = document.getElementById('f-rama').value;
+    const cFilter = document.getElementById('f-categoria').value;
+    const dFilter = document.getElementById('f-delegacion').value;
+    const filtered = equiposData.filter(eq => {
+      if (rFilter && eq.rama !== rFilter) return false;
+      if (cFilter && eq.categoria !== cFilter) return false;
+      if (dFilter && eq.delegacionId !== dFilter) return false;
+      return true;
+    });
+    exportRows = filtered.map(eq => ({
+      nombre: eq.nombre,
+      rama: eq.rama || '',
+      categoria: eq.categoria || '',
+      delegacion: delegMap[eq.delegacionId] || ''
+    }));
+    const rows = filtered.map(eq => `<tr>
+        <td data-label="Nombre">${eq.nombre}</td>
+        <td data-label="Rama">${eq.rama||''}</td>
+        <td data-label="Categoría">${eq.categoria||''}</td>
+        <td data-label="Delegación">${delegMap[eq.delegacionId]||''}</td>
+        ${isAdmin?`<td data-label="Acciones">${renderActions(eq.id)}</td>`:''}
+      </tr>`).join('');
     const empty = `<tr><td data-label="Mensaje" colspan="${isAdmin?5:4}">No hay equipos</td></tr>`;
     document.getElementById('list').innerHTML = rows || empty;
+    if (isAdmin) attachRowActions(document.getElementById('list'), { onEdit:id=>openEquipo(id, delegMap), onDelete:id=>deleteEquipo(id) }, true);
+  }
+  const q = query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'));
+  const unsub = onSnapshot(q, snap => {
+    equiposData = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    update();
   });
   pushCleanup(() => unsub());
+  document.getElementById('aplicar').addEventListener('click', update);
+  document.getElementById('limpiar').addEventListener('click', () => {
+    document.getElementById('f-rama').value = '';
+    document.getElementById('f-categoria').value = '';
+    document.getElementById('f-delegacion').value = '';
+    update();
+  });
   document.getElementById('exportar-pdf').addEventListener('click', () => {
     const body = [
       [
@@ -94,7 +133,6 @@ export async function render(el) {
   });
   if (isAdmin) {
     document.getElementById('nuevo').addEventListener('click', () => openEquipo(null, delegMap));
-    attachRowActions(document.getElementById('list'), { onEdit:id=>openEquipo(id, delegMap), onDelete: id=>deleteEquipo(id) }, true);
   }
 }
 


### PR DESCRIPTION
## Summary
- add delegation, category, branch and matchday filters to Equipos, Partidos and Cobros
- filter data in each section based on selected values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd1ad2ec48325802d6d5ed008228e