### PR TITLE
Añade filtro por estado de cobro y confirmación al eliminar

### DIFF
--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -46,6 +46,12 @@ export async function render(el) {
         <select id="f-rama" class="input"><option value="">Rama</option>${ramaOpts}</select>
         <select id="f-categoria" class="input"><option value="">Categoría</option>${categoriaOpts}</select>
         <select id="f-delegacion" class="input"><option value="">Delegación</option>${delegacionOpts}</select>
+        <select id="f-estado" class="input">
+          <option value="">Estado</option>
+          <option value="Pagado">Pagado</option>
+          <option value="Parcial">Parcial</option>
+          <option value="Pendiente">Pendiente</option>
+        </select>
         <button id="aplicar" class="btn btn-secondary">Aplicar</button>
         <button id="limpiar" class="btn btn-secondary">Limpiar</button>
       </div>
@@ -75,6 +81,7 @@ export async function render(el) {
     const rFilter = document.getElementById('f-rama').value;
     const cFilter = document.getElementById('f-categoria').value;
     const dFilter = document.getElementById('f-delegacion').value;
+    const eFilter = document.getElementById('f-estado').value;
     exportRows = [];
     totalMonto = 0;
     const rows = [];
@@ -102,6 +109,7 @@ export async function render(el) {
         if (!monto) { status = 'Pendiente'; badgeClass = 'badge-danger'; }
         else if (monto < tarifa) { status = 'Parcial'; badgeClass = 'badge-warning'; }
         else { status = 'Pagado'; badgeClass = 'badge-success'; }
+        if (eFilter && status !== eFilter) return;
         const color = status === 'Pagado' ? 'green' : status === 'Parcial' ? 'orange' : 'red';
         rows.push(`<tr>
           <td data-label="Jornada">${jornada}</td>
@@ -155,6 +163,7 @@ export async function render(el) {
     document.getElementById('f-rama').value = '';
     document.getElementById('f-categoria').value = '';
     document.getElementById('f-delegacion').value = '';
+    document.getElementById('f-estado').value = '';
     update();
   });
   document.getElementById('exportar-pdf').addEventListener('click', () => {

--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -59,6 +59,12 @@ export async function render(el) {
         <select id="f-rama" class="input"><option value="">Rama</option>${ramaOpts}</select>
         <select id="f-categoria" class="input"><option value="">Categoría</option>${categoriaOpts}</select>
         <select id="f-delegacion" class="input"><option value="">Delegación</option>${delegacionOpts}</select>
+        <select id="f-estado" class="input">
+          <option value="">Estado</option>
+          <option value="Pagado">Pagado</option>
+          <option value="Parcial">Parcial</option>
+          <option value="Pendiente">Pendiente</option>
+        </select>
         <button id="aplicar" class="btn btn-secondary">Aplicar</button>
         <button id="limpiar" class="btn btn-secondary">Limpiar</button>
       </div>
@@ -74,6 +80,7 @@ export async function render(el) {
     const rFilter = document.getElementById('f-rama').value;
     const cFilter = document.getElementById('f-categoria').value;
     const dFilter = document.getElementById('f-delegacion').value;
+    const eFilter = document.getElementById('f-estado').value;
 
     const filtered = partidos.filter(pa => {
       if (jFilter && pa.jornadaId !== jFilter) return false;
@@ -113,6 +120,7 @@ export async function render(el) {
         if (!monto) status = 'Pendiente';
         else if (monto < tarifa) status = 'Parcial';
         else status = 'Pagado';
+        if (eFilter && status !== eFilter) return;
         const rowHtml = `<tr>
           <td data-label="Jornada">${jornada}</td>
           <td data-label="Rama">${rama}</td>
@@ -194,6 +202,7 @@ export async function render(el) {
     document.getElementById('f-rama').value = '';
     document.getElementById('f-categoria').value = '';
     document.getElementById('f-delegacion').value = '';
+    document.getElementById('f-estado').value = '';
     update();
   });
 

--- a/src/ui/row-actions.js
+++ b/src/ui/row-actions.js
@@ -6,7 +6,9 @@ export function attachRowActions(container, { onEdit, onDelete }, isAdmin) {
     const id = btn.dataset.id;
     const action = btn.dataset.action;
     if (action === 'edit') onEdit(id);
-    else if (action === 'delete') onDelete(id);
+    else if (action === 'delete') {
+      if (confirm('¿Estás seguro de eliminar este registro?')) onDelete(id);
+    }
   });
 }
 export function renderActions(id) {


### PR DESCRIPTION
## Resumen
- Agrega filtro de **Estado** en las vistas de Cobros y Reportes
- Aplica el filtro de estado al generar tablas y datos exportables
- Solicita confirmación antes de ejecutar acciones de eliminar

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b077fae90083259145ab46eb0d0028