### PR TITLE
fix: make cancel button close modals

### DIFF
--- a/src/core/modal-manager.js
+++ b/src/core/modal-manager.js
@@ -24,3 +24,9 @@ export function closeModal() {
   modal.style.display = 'none';
   document.body.style.overflow = '';
 }
+
+// Expose closeModal globally so that inline event handlers like
+// <button onclick="closeModal()">Cancelar</button> can access it. This
+// solves the "closeModal is not defined" error triggered when clicking
+// the Cancel button inside modal dialogs.
+window.closeModal = closeModal;


### PR DESCRIPTION
## Summary
- expose `closeModal` globally so cancel buttons can close dialogs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b094a0fd0083259cd4144fd0dadedd