### PR TITLE
Fix responsive menu visibility

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -42,6 +42,7 @@ export function renderShell() {
   const drawer = document.getElementById('drawer');
   const overlay = document.getElementById('drawer-overlay');
   const torneoSelect = document.getElementById('torneo-switch');
+  const mql = window.matchMedia('(min-width:1025px)');
   watchTorneos(list => {
     torneoSelect.innerHTML = list.map(t => `<option value="${t.id}">${t.nombre}</option>`).join('');
     if (!getActiveTorneo() && list.length) setActiveTorneo(list[0].id);
@@ -49,11 +50,24 @@ export function renderShell() {
   });
   torneoSelect.addEventListener('change', e => setActiveTorneo(e.target.value));
   onTorneoChange(id => { torneoSelect.value = id || ''; });
+  function updateDrawer() {
+    if (mql.matches) {
+      drawer.hidden = false;
+      overlay.hidden = true;
+    } else {
+      drawer.hidden = true;
+      overlay.hidden = true;
+    }
+  }
   function closeDrawer() {
+    if (mql.matches) return;
     drawer.hidden = true;
     overlay.hidden = true;
   }
+  updateDrawer();
+  mql.addEventListener('change', updateDrawer);
   menuBtn.addEventListener('click', () => {
+    if (mql.matches) return;
     drawer.hidden = !drawer.hidden;
     overlay.hidden = drawer.hidden;
   });

--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -110,6 +110,22 @@ body {
   pointer-events: auto;
 }
 
+@media (min-width:1025px) {
+  #app {
+    padding-left: calc(260px + var(--space-4));
+  }
+  .drawer {
+    transform: none;
+    top: var(--topbar-h);
+    width: 260px;
+    box-shadow: none;
+  }
+  #menu-btn,
+  .drawer-overlay {
+    display: none;
+  }
+}
+
 .tabbar {
   position: fixed;
   bottom: 0; left: 0; right: 0;


### PR DESCRIPTION
## Summary
- keep navigation drawer permanently visible on desktop screens
- automatically hide the drawer and use overlay toggle on tablets and phones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cb5d5a2883258291937486cd8be3