### PR TITLE
Add tooltips to action icons

### DIFF
--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -2,11 +2,11 @@ import { watchTorneos, getActiveTorneo, setActiveTorneo, onTorneoChange } from '
 
 const shellHtml = `
 <header class="topbar">
-  <button id="menu-btn" class="icon-btn" aria-label="Abrir menú">
+  <button id="menu-btn" class="icon-btn" aria-label="Abrir menú" title="Abrir menú">
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#menu"></use></svg>
   </button>
   <div id="user-info" class="topbar-title">Berumen <span id="user-role" class="chip"></span></div>
-  <button id="logout-btn" class="icon-btn" onclick="appLogout()" aria-label="Configuración" hidden>
+  <button id="logout-btn" class="icon-btn" onclick="appLogout()" aria-label="Configuración" title="Configuración" hidden>
     <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#settings"></use></svg>
   </button>
   <select id="torneo-switch" class="input"></select>

--- a/src/features/arbitros.js
+++ b/src/features/arbitros.js
@@ -38,7 +38,7 @@ export async function render(el) {
       <table class="responsive-table"><thead><tr><th>Nombre</th><th>Teléfono</th><th>Email</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
       <div class="toolbar"><button id="exportar-pdf" class="btn btn-secondary">Exportar PDF</button></div>
     </div>
-    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo árbitro"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
+    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo árbitro" title="Nuevo árbitro"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   const q = query(collection(db, paths.arbitros()), orderBy('nombre'));
   let exportRows = [];
   const arbitrosData = {};

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -279,18 +279,18 @@ export async function render(el) {
 
 function renderCobroActions(cobroId, partidoId, equipoId) {
   if (cobroId) return `<span class="row-actions">
-    <button class="icon-btn" data-action="edit" data-id="${cobroId}" aria-label="Editar">
+    <button class="icon-btn" data-action="edit" data-id="${cobroId}" aria-label="Editar" title="Editar">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#edit"></use></svg>
     </button>
-    <button class="icon-btn" data-action="ticket" data-id="${cobroId}" aria-label="Ticket">
+    <button class="icon-btn" data-action="ticket" data-id="${cobroId}" aria-label="Ticket" title="Ticket">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#ticket"></use></svg>
     </button>
-    <button class="icon-btn" data-action="delete" data-id="${cobroId}" aria-label="Eliminar">
+    <button class="icon-btn" data-action="delete" data-id="${cobroId}" aria-label="Eliminar" title="Eliminar">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#trash"></use></svg>
     </button>
   </span>`;
   return `<span class="row-actions">
-    <button class="icon-btn" data-action="edit" data-id="partido:${partidoId}:equipo:${equipoId}" aria-label="Registrar cobro">
+    <button class="icon-btn" data-action="edit" data-id="partido:${partidoId}:equipo:${equipoId}" aria-label="Registrar cobro" title="Registrar cobro">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#edit"></use></svg>
     </button>
   </span>`;

--- a/src/features/partidos.js
+++ b/src/features/partidos.js
@@ -48,7 +48,7 @@ export async function render(el) {
         <button id="exportar-pdf" class="btn btn-secondary">Exportar PDF</button>
       </div>
     </div>
-    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo partido"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
+    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nuevo partido" title="Nuevo partido"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   let partidosData = [];
   let exportRows = [];
   function update() {

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -19,7 +19,7 @@ export async function render(el) {
       <table class="responsive-table"><thead><tr><th>Rama</th><th>Categoría</th><th>Tarifa</th>${isAdmin?'<th>Acciones</th>':''}</tr></thead><tbody id="list"></tbody></table>
       <div class="toolbar"><button id="exportar-pdf" class="btn btn-secondary">Exportar PDF</button></div>
     </div>
-    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nueva tarifa"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
+    ${isAdmin ? '<button id="fab-nuevo" class="fab" aria-label="Nueva tarifa" title="Nueva tarifa"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg></button>' : ''}`;
   const toSnap = await getDoc(doc(db, paths.torneos(), getActiveTorneo()));
   const ligaNombre = toSnap.data()?.nombre || '';
   const q = query(collection(db, paths.tarifas()), where('torneoId','==',getActiveTorneo()), orderBy('rama'), orderBy('categoria'));

--- a/src/ui/row-actions.js
+++ b/src/ui/row-actions.js
@@ -24,13 +24,13 @@ export function attachRowActions(container, handlers, isAdmin) {
 
 export function renderActions(id, extra = []) {
   return `<span class="row-actions">
-    <button class="icon-btn" data-action="edit" data-id="${id}" aria-label="Editar">
+    <button class="icon-btn" data-action="edit" data-id="${id}" aria-label="Editar" title="Editar">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#edit"></use></svg>
     </button>
-    <button class="icon-btn" data-action="delete" data-id="${id}" aria-label="Eliminar">
+    <button class="icon-btn" data-action="delete" data-id="${id}" aria-label="Eliminar" title="Eliminar">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#trash"></use></svg>
     </button>
-    ${extra.map(a => `<button class="icon-btn" data-action="${a.action}" data-id="${id}" aria-label="${a.label}">
+    ${extra.map(a => `<button class="icon-btn" data-action="${a.action}" data-id="${id}" aria-label="${a.label}" title="${a.label}">
       <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#${a.icon}"></use></svg>
     </button>`).join('')}
   </span>`;


### PR DESCRIPTION
## Summary
- add `title` tooltips to shell icon buttons
- include tooltips on row action buttons and feature FABs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1db1442a883258a5707e0bc3811ca