### PR TITLE
feat: add home dashboard skeleton

### DIFF
--- a/src/features/home.js
+++ b/src/features/home.js
@@ -1,15 +1,168 @@
-import { addDiagnostic } from '../data/repo.js';
-import { getAuth } from '../data/firebase.js';
+import { getUserRole } from '../core/auth.js';
+import { pushCleanup } from '../core/router.js';
 
+/**
+ * Renderiza la pantalla Home con secciones de tablero.
+ * Solo UI: los datos se muestran como placeholders.
+ */
 export async function render(el) {
-  el.innerHTML = `<div class="card"><h1 class="h1">Home</h1><button id="smoke" class="btn btn-secondary">Probar escritura</button><div id="result" class="mt-4"></div></div>`;
-  document.getElementById('smoke').addEventListener('click', async () => {
-    const uid = getAuth().currentUser.uid;
-    try {
-      const res = await addDiagnostic('smoke', uid);
-      document.getElementById('result').textContent = 'Escribió id ' + res.id;
-    } catch (e) {
-      document.getElementById('result').textContent = 'Error: ' + e.message;
-    }
+  // Topbar: título liga + chip rol + selector de rango
+  const topbarTitle = document.getElementById('user-info');
+  const previousTopbar = topbarTitle.innerHTML;
+  const role = getUserRole();
+  topbarTitle.innerHTML = `Berumen Sports • Liga 2025 <span class="chip">${role}</span>`;
+  const range = document.createElement('select');
+  range.id = 'home-range';
+  range.className = 'input';
+  range.setAttribute('aria-label', 'Seleccionar rango');
+  range.innerHTML = `
+    <option value="hoy">Hoy</option>
+    <option value="semana">Semana</option>
+    <option value="mes">Mes</option>
+    <option value="temporada">Temporada</option>
+  `;
+  topbarTitle.after(range);
+  pushCleanup(() => {
+    topbarTitle.innerHTML = previousTopbar;
+    range.remove();
+  });
+
+  // UI principal
+  el.innerHTML = `
+    <section class="home-kpis" aria-label="Indicadores clave">
+      <a href="#/equipos" class="kpi-card" role="link" aria-label="Equipos">
+        <span class="kpi-main" id="kpi-equipos">0</span>
+        <span class="kpi-label">Equipos</span>
+        <span class="kpi-delta" aria-label="Variación">0</span>
+      </a>
+      <a href="#/partidos" class="kpi-card" role="link" aria-label="Partidos">
+        <span class="kpi-main" id="kpi-partidos">0</span>
+        <span class="kpi-label">Partidos</span>
+        <span class="kpi-delta" aria-label="Variación">0</span>
+      </a>
+      <a href="#/cobros" class="kpi-card" role="link" aria-label="Cobros pendientes">
+        <span class="kpi-main" id="kpi-pendientes">0</span>
+        <span class="kpi-label">Cobros pendientes</span>
+        <span class="kpi-delta" aria-label="Variación">0</span>
+      </a>
+      <a href="#/cobros" class="kpi-card" role="link" aria-label="Recaudado">
+        <span class="kpi-main" id="kpi-recaudado">$0</span>
+        <span class="kpi-label">Recaudado</span>
+        <span class="kpi-delta" aria-label="Variación">0</span>
+      </a>
+      <a href="#/arbitros" class="kpi-card" role="link" aria-label="Árbitros activos">
+        <span class="kpi-main" id="kpi-arbitros">0</span>
+        <span class="kpi-label">Árbitros activos</span>
+        <span class="kpi-delta" aria-label="Variación">0</span>
+      </a>
+    </section>
+
+    <div class="card" id="home-upcoming">
+      <h2 class="h2">Próximos partidos</h2>
+      <ul class="home-list" role="list" id="upcoming-list">
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+      </ul>
+      <div class="toolbar">
+        <a href="#/partidos" class="btn btn-secondary">Ver todos</a>
+      </div>
+    </div>
+
+    <div class="card" id="home-finance">
+      <h2 class="h2">Snapshot financiero</h2>
+      <div class="finance-cards">
+        <div class="finance-card">
+          <span class="finance-label">Facturado</span>
+          <span class="finance-value" id="fin-facturado">$0</span>
+        </div>
+        <div class="finance-card">
+          <span class="finance-label">Cobrado</span>
+          <span class="finance-value" id="fin-cobrado">$0</span>
+        </div>
+        <div class="finance-card">
+          <span class="finance-label">Por cobrar</span>
+          <span class="finance-value" id="fin-porcobrar">$0</span>
+        </div>
+      </div>
+      <ul class="home-list" role="list" aria-label="Top deudores" id="top-deudores">
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+      </ul>
+      <div class="toolbar">
+        <a href="#/cobros" class="btn btn-primary">Registrar cobro</a>
+        <a href="#/reportes" class="btn btn-secondary">Ver reportes</a>
+      </div>
+    </div>
+
+    <div class="card" id="home-alerts">
+      <h2 class="h2">Alertas</h2>
+      <div class="alerts-wrap" role="list">
+        <div class="alert-item skeleton" aria-hidden="true"></div>
+        <div class="alert-item skeleton" aria-hidden="true"></div>
+      </div>
+    </div>
+
+    <div class="card" id="home-activity">
+      <h2 class="h2">Actividad reciente</h2>
+      <ul class="home-list" role="list" id="activity-list">
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+        <li class="skeleton" aria-hidden="true"></li>
+      </ul>
+    </div>
+
+    <div class="card desktop-only" id="quick-actions">
+      <h2 class="h2">Acciones rápidas</h2>
+      <div class="qa-grid">
+        <a href="#/partidos" class="qa-btn btn btn-secondary">Nuevo partido</a>
+        <a href="#/cobros" class="qa-btn btn btn-secondary">Registrar cobro</a>
+        <a href="#/equipos" class="qa-btn btn btn-secondary">Nuevo equipo</a>
+        <a href="#/tarifas" class="qa-btn btn btn-secondary">Nueva tarifa</a>
+      </div>
+    </div>
+    <button id="fab-qa" class="fab mobile-only" aria-label="Acciones rápidas">
+      <svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#plus"></use></svg>
+    </button>
+
+    <div class="card" id="home-reports">
+      <h2 class="h2">Reportes destacados</h2>
+      <div class="reports-grid">
+        <a href="#/reportes" class="report-card">Cobros por delegación</a>
+        <a href="#/reportes" class="report-card">Partidos por estado</a>
+        <a href="#/reportes" class="report-card">Ingresos por periodo</a>
+      </div>
+    </div>
+
+    <div class="card" id="home-onboarding" hidden>
+      <h2 class="h2">Primeros pasos</h2>
+      <ol class="onboarding-list">
+        <li>Crear delegaciones</li>
+        <li>Cargar tarifas</li>
+        <li>Crear equipos</li>
+        <li>Programar partido</li>
+        <li>Registrar primer cobro</li>
+      </ol>
+    </div>
+  `;
+
+  // Salud del sistema
+  const health = document.createElement('div');
+  health.id = 'system-health';
+  health.className = 'system-health';
+  document.body.appendChild(health);
+  function updateHealth() {
+    health.textContent = navigator.onLine ? 'Online' : 'Offline';
+  }
+  updateHealth();
+  window.addEventListener('online', updateHealth);
+  window.addEventListener('offline', updateHealth);
+  pushCleanup(() => {
+    window.removeEventListener('online', updateHealth);
+    window.removeEventListener('offline', updateHealth);
+    health.remove();
   });
 }

--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -222,3 +222,51 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
 @media (min-width: 768px) {
   .mobile-only { display: none !important; }
 }
+/* Home specific styles */
+.home-kpis {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+@media (min-width:768px) {
+  .home-kpis { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width:1024px) {
+  .home-kpis { grid-template-columns: repeat(4, 1fr); }
+}
+.kpi-card {
+  background: var(--color-surface);
+  border:1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-1);
+  padding: var(--space-3);
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-2);
+  text-decoration:none;
+  color:inherit;
+}
+.kpi-main { font-size: var(--fs-h2); font-weight:600; }
+.kpi-label { font-size: var(--fs-label); }
+.kpi-delta { font-size: var(--fs-label); color: var(--color-text-muted); }
+
+.home-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:var(--space-3); }
+
+.finance-cards { display:flex; flex-wrap:wrap; gap:var(--space-4); margin-bottom:var(--space-4); }
+.finance-card { flex:1; min-width:120px; background:var(--color-surface-elevated); border-radius:var(--radius-md); padding:var(--space-3); display:flex; flex-direction:column; gap:var(--space-1); }
+.finance-label { font-size:var(--fs-label); color:var(--color-text-muted); }
+.finance-value { font-size:var(--fs-h2); }
+
+.alerts-wrap { display:flex; flex-direction:column; gap:var(--space-3); }
+.alert-item { background:var(--color-surface-elevated); border-radius:var(--radius-md); height:32px; }
+
+.qa-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:var(--space-4); }
+.reports-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:var(--space-4); }
+.report-card { display:block; padding:var(--space-4); background:var(--color-surface-elevated); border-radius:var(--radius-md); text-decoration:none; color:inherit; text-align:center; }
+.onboarding-list { margin:0; padding-left:var(--space-4); display:flex; flex-direction:column; gap:var(--space-2); }
+
+.system-health { position:fixed; bottom:0; left:0; right:0; height:24px; text-align:center; font-size:var(--fs-label); background:var(--color-surface-elevated); color:var(--color-text-strong); }
+
+.skeleton { background:var(--color-surface-elevated); border-radius:var(--radius-md); height:24px; animation: skeleton-pulse 1.5s infinite ease-in-out; }
+@keyframes skeleton-pulse { 0% { opacity:0.6; } 50% { opacity:1; } 100% { opacity:0.6; } }


### PR DESCRIPTION
## Summary
- build Home screen with placeholder dashboard sections and range selector
- add responsive styles and skeleton utilities for Home components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1de0a931c832591a24bab073a4dc0