### PR TITLE
Fix modal overflow for match input

### DIFF
--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -152,6 +152,7 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
   box-shadow: var(--shadow-2);
   display:flex; flex-direction:column;
   padding:var(--space-4);
+  overflow-y:auto;
 }
 .modal-header { font-weight:600; margin-bottom:var(--space-4); }
 .modal-body { overflow:auto; flex:1; }


### PR DESCRIPTION
## Summary
- allow modal windows to scroll vertically so score fields and action buttons remain accessible on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b71205c6a08325ae81b9fe7fedf882