### PR TITLE
Disable backdrop closing for modals and add close button

### DIFF
--- a/src/core/modal-manager.js
+++ b/src/core/modal-manager.js
@@ -10,12 +10,11 @@ export function openModal(content) {
       background: 'rgba(0,0,0,0.3)', display: 'flex',
       alignItems: 'flex-end', justifyContent: 'center', zIndex: 1100
     });
-    modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
     document.getElementById('modal-root').appendChild(modal);
   }
   modal.style.display = 'flex';
   modal.style.bottom = mb + 'px';
-  modal.innerHTML = `<div class="modal-sheet">${content}</div>`;
+  modal.innerHTML = `<div class="modal-sheet"><button type="button" class="modal-close" aria-label="Cerrar" onclick="closeModal()">&times;</button>${content}</div>`;
   document.body.style.overflow = 'hidden';
 }
 export function closeModal() {

--- a/src/ui/components.css
+++ b/src/ui/components.css
@@ -154,6 +154,16 @@ label, .label { font-size: var(--fs-label); font-weight:500; }
   padding:var(--space-4);
   overflow-y:auto;
 }
+.modal-close {
+  position:absolute;
+  top:var(--space-3);
+  right:var(--space-3);
+  background:transparent;
+  border:none;
+  font-size:1.25rem;
+  line-height:1;
+  cursor:pointer;
+}
 .modal-header { font-weight:600; margin-bottom:var(--space-4); }
 .modal-body { overflow:auto; flex:1; }
 .modal-footer { display:flex; justify-content:flex-end; gap:var(--space-3); margin-top:var(--space-4); }


### PR DESCRIPTION
## Summary
- prevent modal dialogs from dismissing when clicking the backdrop
- add top-right "X" button to close modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9de00e3a88325a63366968bae20d3