### PR TITLE
Add dynamic categorias section and integrate catalog

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -48,6 +48,14 @@
       ]
     },
     {
+      "collectionGroup": "categorias",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath":"torneoId","order":"ASCENDING"},
+        {"fieldPath":"nombre","order":"ASCENDING"}
+      ]
+    },
+    {
       "collectionGroup": "tarifas",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -4,6 +4,7 @@ const routes = {
   '/': () => import('../features/home.js'),
   '/equipos': () => import('../features/equipos.js'),
   '/delegaciones': () => import('../features/delegaciones.js'),
+  '/categorias': () => import('../features/categorias.js'),
   '/arbitros': () => import('../features/arbitros.js'),
   '/torneos': () => import('../features/torneos.js'),
   '/partidos': () => import('../features/partidos.js'),

--- a/src/core/shell.js
+++ b/src/core/shell.js
@@ -16,6 +16,7 @@ const shellHtml = `
     <li><a href="#/"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#home"></use></svg><span>Home</span></a></li>
     <li><a href="#/torneos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#chart"></use></svg><span>Torneos</span></a></li>
     <li><a href="#/delegaciones"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#user"></use></svg><span>Delegaciones</span></a></li>
+    <li><a href="#/categorias"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#document"></use></svg><span>Categorías</span></a></li>
     <li><a href="#/equipos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#users"></use></svg><span>Equipos</span></a></li>
     <li><a href="#/partidos"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#calendar"></use></svg><span>Partidos</span></a></li>
     <li><a href="#/jornadas"><svg class="icon" aria-hidden="true"><use href="/assets/icons.svg#calendar"></use></svg><span>Jornadas</span></a></li>

--- a/src/data/paths.js
+++ b/src/data/paths.js
@@ -4,6 +4,7 @@ export const paths = {
   users: () => 'users',
   torneos: () => 'torneos',
   delegaciones: () => 'delegaciones',
+  categorias: () => 'categorias',
   equipos: () => 'equipos',
   arbitros: () => 'arbitros',
   tarifas: () => 'tarifas',

--- a/src/data/repo.js
+++ b/src/data/repo.js
@@ -31,6 +31,15 @@ export function updateDelegacion(id, data) {
 export function deleteDelegacion(id) {
   return safeWrite(() => deleteDoc(doc(db, paths.delegaciones(), id)), 'deleteDelegacion');
 }
+export function addCategoria(data) {
+  return safeWrite(() => addDoc(collection(db, paths.categorias()), { ...data, torneoId: getActiveTorneo() }), 'addCategoria');
+}
+export function updateCategoria(id, data) {
+  return safeWrite(() => updateDoc(doc(db, paths.categorias(), id), data), 'updateCategoria');
+}
+export function deleteCategoria(id) {
+  return safeWrite(() => deleteDoc(doc(db, paths.categorias(), id)), 'deleteCategoria');
+}
 export function addArbitro(data) {
   return safeWrite(() => addDoc(collection(db, paths.arbitros()), data), 'addArbitro');
 }

--- a/src/features/cobros.js
+++ b/src/features/cobros.js
@@ -11,7 +11,7 @@ import { exportToPdf } from '../pdf/export.js';
 export async function render(el) {
   const isAdmin = getUserRole() === 'admin';
   const fmt = new Intl.NumberFormat('es-MX',{style:'currency',currency:'MXN',maximumFractionDigits:0});
-  const [eqSnap, paSnap, taSnap, joSnap, delSnap, toSnap] = await Promise.all([
+  const [eqSnap, paSnap, taSnap, joSnap, delSnap, toSnap, catSnap] = await Promise.all([
     getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()))),
     getDocs(query(
       collection(db, paths.partidos()),
@@ -21,7 +21,8 @@ export async function render(el) {
     getDocs(query(collection(db, paths.tarifas()), where('torneoId','==',getActiveTorneo()))),
     getDocs(query(collection(db, paths.jornadas()), where('torneoId','==',getActiveTorneo()))),
     getDocs(query(collection(db, paths.delegaciones()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'))),
-    getDoc(doc(db, paths.torneos(), getActiveTorneo()))
+    getDoc(doc(db, paths.torneos(), getActiveTorneo())),
+    getDocs(query(collection(db, paths.categorias()), where('torneoId','==',getActiveTorneo()), orderBy('nombre')))
   ]);
   const equiposData = eqSnap.docs.map(d => ({ id: d.id, ...d.data() }));
   const equipos = Object.fromEntries(equiposData.map(d => [d.id, d]));
@@ -31,7 +32,7 @@ export async function render(el) {
   const delegaciones = Object.fromEntries(delSnap.docs.map(d => [d.id, d.data().nombre]));
   const ligaNombre = toSnap.data()?.nombre || '';
   const ramas = [...new Set(equiposData.map(e => e.rama).filter(Boolean))];
-  const categorias = [...new Set(equiposData.map(e => e.categoria).filter(Boolean))];
+  const categorias = catSnap.docs.map(d => d.data().nombre);
   const jornadaOpts = Object.entries(jornadas).map(([id,n]) => `<option value="${id}">${n}</option>`).join('');
   const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
   const categoriaOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');

--- a/src/features/reportes.js
+++ b/src/features/reportes.js
@@ -6,7 +6,7 @@ import { exportToPdf } from '../pdf/export.js';
 export async function render(el) {
   const fmt = new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN', maximumFractionDigits: 0 });
 
-  const [eqSnap, paSnap, coSnap, taSnap, joSnap, delSnap, toSnap] = await Promise.all([
+  const [eqSnap, paSnap, coSnap, taSnap, joSnap, delSnap, toSnap, catSnap] = await Promise.all([
     getDocs(query(collection(db, paths.equipos()), where('torneoId', '==', getActiveTorneo()))),
     getDocs(query(
       collection(db, paths.partidos()),
@@ -21,7 +21,8 @@ export async function render(el) {
     getDocs(query(collection(db, paths.tarifas()), where('torneoId', '==', getActiveTorneo()))),
     getDocs(query(collection(db, paths.jornadas()), where('torneoId', '==', getActiveTorneo()))),
     getDocs(query(collection(db, paths.delegaciones()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'))),
-    getDoc(doc(db, paths.torneos(), getActiveTorneo()))
+    getDoc(doc(db, paths.torneos(), getActiveTorneo())),
+    getDocs(query(collection(db, paths.categorias()), where('torneoId','==',getActiveTorneo()), orderBy('nombre')))
   ]);
 
   const equipos = Object.fromEntries(eqSnap.docs.map(d => [d.id, d.data()]));
@@ -36,7 +37,7 @@ export async function render(el) {
   const jornadas = Object.fromEntries(joSnap.docs.map(d => [d.id, d.data().nombre]));
   const delegaciones = Object.fromEntries(delSnap.docs.map(d => [d.id, d.data().nombre]));
   const ramas = new Set(eqSnap.docs.map(d => d.data().rama).filter(Boolean));
-  const categorias = new Set(eqSnap.docs.map(d => d.data().categoria).filter(Boolean));
+  const categorias = new Set(catSnap.docs.map(d => d.data().nombre));
   let exportData = { rows: [], totalTarifa: 0, totalMonto: 0, totalSaldo: 0 };
   const ligaNombre = toSnap.data()?.nombre || '';
 

--- a/src/features/tarifas.js
+++ b/src/features/tarifas.js
@@ -112,13 +112,14 @@ export async function render(el) {
 
 async function openTarifa(id) {
   const isEdit = !!id;
-  const [eqSnap, taSnap] = await Promise.all([
+  const [eqSnap, catSnap, taSnap] = await Promise.all([
     getDocs(query(collection(db, paths.equipos()), where('torneoId','==',getActiveTorneo()))),
+    getDocs(query(collection(db, paths.categorias()), where('torneoId','==',getActiveTorneo()), orderBy('nombre'))),
     isEdit ? getDoc(doc(db, paths.tarifas(), id)) : Promise.resolve(null)
   ]);
   const equipos = eqSnap.docs.map(d => d.data());
   const ramas = [...new Set(equipos.map(e => e.rama).filter(Boolean))];
-  const categorias = [...new Set(equipos.map(e => e.categoria).filter(Boolean))];
+  const categorias = catSnap.docs.map(d => d.data().nombre);
   const ramaOpts = ramas.map(r => `<option value="${r}">${r}</option>`).join('');
   const catOpts = categorias.map(c => `<option value="${c}">${c}</option>`).join('');
   const existing = taSnap?.exists() ? taSnap.data() : { rama: '', categoria: '', tarifa: '' };


### PR DESCRIPTION
## Summary
- add Categorías CRUD section for tournament-specific category management
- load category options from catalog across equipos, partidos, cobros, tarifas y reportes
- expose categories route and navigation entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb926cc08325a623b6b2d402be90