### PR TITLE
fix: avoid duplicate home-range selector on first load

### DIFF
--- a/src/core/router.js
+++ b/src/core/router.js
@@ -28,7 +28,10 @@ function runCleanup() {
 export function pushCleanup(fn) { cleanupFns.push(fn); }
 
 async function loadRoute() {
-  if (!location.hash) location.replace('#/');
+  if (!location.hash) {
+    location.replace('#/');
+    return;
+  }
   const path = location.hash.slice(1);
   const loader = routes[path];
   if (!loader) return;


### PR DESCRIPTION
## Summary
- prevent double initial route load when no hash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1e8e80f483259e42caaf046f08ec