### PR TITLE
fix: prevent topbar from covering drawer links

### DIFF
--- a/src/ui/layout.css
+++ b/src/ui/layout.css
@@ -79,7 +79,9 @@ body {
 
 .drawer {
   position: fixed;
-  top: 0; bottom: 0; left: 0;
+  top: var(--topbar-h);
+  bottom: 0;
+  left: 0;
   width: 84vw;
   max-width: 320px;
   background: var(--color-surface);


### PR DESCRIPTION
## Summary
- offset drawer from topbar so first menu items remain visible on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7c143d8c8325805c7eeb6d26a72d